### PR TITLE
Add sourceRoot option, fixes #7

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -105,6 +105,11 @@ function getImmutableCompilationSettings(settings: compile.Settings): typescript
 	if (settings.module !== undefined)
 		tsSettings.moduleGenTarget = moduleMap[(settings.module || 'none').toLowerCase()];
 
+	if (settings.sourceRoot === undefined)
+		tsSettings.sourceRoot = process.cwd();
+	else
+		tsSettings.sourceRoot = settings.sourceRoot;
+
 	if (settings.declarationFiles !== undefined)
 		tsSettings.generateDeclarationFiles = settings.declarationFiles;
 	
@@ -124,6 +129,7 @@ module compile {
 		noLib?: boolean;
 		target?: string;
 		module?: string;
+		sourceRoot?: string;
 
 		declarationFiles?: boolean;
 		

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ Options
 - ```noLib``` (boolean) - Don't include the default lib (with definitions for - Array, Date etc)
 - ```target``` (string) - Specify ECMAScript target version: 'ES3' (default), or 'ES5'.
 - ```module``` (string) - Specify module code generation: 'commonjs' or 'amd'
+- ```sourceRoot``` (string) - Specifies the location where debugger should locate TypeScript files instead of source locations.
 - ```declarationFiles``` (boolean) - Generates corresponding .d.ts files.
 - ```noExternalResolve``` (boolean) - Do not resolve files that are not in the input. Explanation below.
 - ```sortOutput``` (boolean) - Sort output files. Usefull if you want to concatenate files (see below).

--- a/release/main.js
+++ b/release/main.js
@@ -110,6 +110,11 @@ function getImmutableCompilationSettings(settings) {
     if (settings.module !== undefined)
         tsSettings.moduleGenTarget = moduleMap[(settings.module || 'none').toLowerCase()];
 
+    if (settings.sourceRoot === undefined)
+        tsSettings.sourceRoot = process.cwd();
+    else
+        tsSettings.sourceRoot = settings.sourceRoot;
+
     if (settings.declarationFiles !== undefined)
         tsSettings.generateDeclarationFiles = settings.declarationFiles;
 


### PR DESCRIPTION
Hi, I fixed #7 issue.
If no `sourceRoot` option is given, the TypeScript compiler truncates paths in `sourceMap.sources` property.

`sourceRoot` given:

``` javascript
{"version":3,"file":"foobar.js","sourceRoot":"./","sources":["src/foobar.ts"],...
```

`sourceRoot` no given:

``` javascript
{"version":3,"file":"foobar.js","sourceRoot":"","sources":["foobar.ts"],...
```

So I added `sourceRoot` option to `gulp-type`. Could you review it?
Thanks.
