### PR TITLE
Don't start compile when input stream is empty.

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -21,6 +21,7 @@ class CompileStream extends stream.Duplex {
 	}
 	
 	private _project: project.Project;
+	private _hasSources: boolean = false;
 	
 	_write(file: gutil.File, encoding, cb = (err?) => {}) {
 		if (!file) return cb();
@@ -32,7 +33,8 @@ class CompileStream extends stream.Duplex {
 		if (file.isStream()) {
 			return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
 		}
-		
+
+		this._hasSources = true;
 		this._project.addFile(file);
 		cb();
 	}
@@ -41,6 +43,11 @@ class CompileStream extends stream.Duplex {
 	}
 	
 	private compile() {
+		if (!this._hasSources) {
+			this.js.push(null);
+			this.dts.push(null);
+			return;
+		}
 		this._project.resolveAll(() => {
 			this._project.compile(this.js, this.dts, (err) => { 
 				console.error(err.message);

--- a/release/main.js
+++ b/release/main.js
@@ -14,6 +14,7 @@ var CompileStream = (function (_super) {
     __extends(CompileStream, _super);
     function CompileStream(proj) {
         _super.call(this, { objectMode: true });
+        this._hasSources = false;
         this.dts = new CompileOutputStream();
         this._project = proj;
         // Backwards compatibility
@@ -34,6 +35,7 @@ var CompileStream = (function (_super) {
         if (file.isStream()) {
             return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
         }
+        this._hasSources = true;
         this._project.addFile(file);
         cb();
     };
@@ -41,6 +43,11 @@ var CompileStream = (function (_super) {
     };
     CompileStream.prototype.compile = function () {
         var _this = this;
+        if (!this._hasSources) {
+            this.js.push(null);
+            this.dts.push(null);
+            return;
+        }
         this._project.resolveAll(function () {
             _this._project.compile(_this.js, _this.dts, function (err) {
                 console.error(err.message);


### PR DESCRIPTION
Our builds consist of many invocations to the TypeScript compiler, for different 'sub-projects'.
We have a filter in the gulp streams that only pass through changed files, so for rebuilds, most streams are in fact empty.

Currently, when a gulp-typescript pipeline ends, the compiler is 'started', even when no files have been passed to the stream.

This commit makes gulp-typescript skip the compile-call when the stream was empty, saving about 1-2 seconds per pipeline on my machine.
