### PR TITLE
Enable output filter in intelliJ by full file name, adjust error message...

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -259,7 +259,7 @@ export class Project {
 			character: endPos.character
 		};
 
-		err.message = gutil.colors.red(filename + '(' + startPos.line + ',' + startPos.character + '): ') + info.code + ' ' + info.messageText;
+		err.message = gutil.colors.red(err.fullFilename + '(' + startPos.line + ',' + startPos.character + '): ') + "error TS" + info.code + ' ' + info.messageText;
 
 		return err;
 	}

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -259,7 +259,7 @@ export class Project {
 			character: endPos.character
 		};
 
-		err.message = gutil.colors.red(err.fullFilename + '(' + startPos.line + ',' + startPos.character + '): ') + "error TS" + info.code + ' ' + info.messageText;
+		err.message = gutil.colors.red(filename + '(' + startPos.line + ',' + startPos.character + '): ') + info.code + ' ' + info.messageText;
 
 		return err;
 	}

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -37,10 +37,14 @@ export function defaultReporter(): Reporter {
 		}
 	};
 }
-export function intelliJReporter: Reporter {
+export function longReporter(): Reporter {
 	return {
 		error: (error: TypeScriptError) => {
-			console.error('[' + gutil.colors.gray('gulp-typescript') + '] ' + gutil.colors.red(error.fullFilename + '(' + error.startPosition.line + ',' + error.startPosition.character + '): ') + "error TS" + error.diagnostic.code + ' ' + error.diagnostic.messageText);
+			if (error.tsFile) {
+				console.error('[' + gutil.colors.gray('gulp-typescript') + '] ' + gutil.colors.red(error.fullFilename + '(' + error.startPosition.line + ',' + error.startPosition.character + '): ') + 'error TS' + error.diagnostic.code + ' ' + error.diagnostic.messageText);
+			} else {
+				console.error(error.message);
+			}
 		}
 	}
 }

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -37,6 +37,13 @@ export function defaultReporter(): Reporter {
 		}
 	};
 }
+export function intelliJReporter: Reporter {
+	return {
+		error: (error: TypeScriptError) => {
+			console.error('[' + gutil.colors.gray('gulp-typescript') + '] ' + gutil.colors.red(error.fullFilename + '(' + error.startPosition.line + ',' + error.startPosition.character + '): ') + "error TS" + error.diagnostic.code + ' ' + error.diagnostic.messageText);
+		}
+	}
+}
 export function fullReporter(fullFilename: boolean = false): Reporter {
 	return {
 		error: (error: TypeScriptError) => {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     {
       "name": "James Whitney",
       "email": "james@whitney.io"
+    },
+    {
+      "name": "Jaroslaw Zalucki",
+      "email": "mad.jaro@gmail.com"
     }
   ],
   "main": "release/main.js",

--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,7 @@ ts(optionsOrProject, filters, reporter);
 You can set options, project or filter to `undefined` if you don't want to set them. Available reporters are:
 - nullReporter (`ts.reporter.nullReporter()`) - Don't report errors
 - defaultReporter (`ts.reporter.defaultReporter()`) - Report basic errors to the console
+- longReporter (`ts.reporter.longReporter()`) - Extended version of default reporter, intelliJ link functionality + file watcher error highlighting should work using this one
 - fullReporter (`ts.reporter.fullReporter(showFullFilename?: boolean)`) - Show full error messages, with source.
 
 If you want to build a custom reporter, you take a look at `lib/reporter.ts`, in that file is an interface which a reporter should implement.


### PR DESCRIPTION
... so intelliJ can show error in file after file watcher run.