### PR TITLE
Output resolved modules' files

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -79,7 +79,7 @@ export class Output {
 				&& (file.content[OutputFileKind.Definitions] !== undefined || !this.project.options.declaration)) {
 
 				file.sourceMap = JSON.parse(file.content[OutputFileKind.SourceMap]);
-				if (this.project.singleOutput) {
+				if (this.project.singleOutput || this.project.noExternalResolve) {
 					file.original = this.project.input.firstSourceFile;
 					file.sourceMapOrigins = this.project.input.getFileNames(true).map(fName => this.project.input.getFile(fName));
 				} else {

--- a/release/output.js
+++ b/release/output.js
@@ -49,7 +49,7 @@ var Output = (function () {
                 && file.content[OutputFileKind.SourceMap] !== undefined
                 && (file.content[OutputFileKind.Definitions] !== undefined || !this.project.options.declaration)) {
                 file.sourceMap = JSON.parse(file.content[OutputFileKind.SourceMap]);
-                if (this.project.singleOutput) {
+                if (this.project.singleOutput || this.project.noExternalResolve) {
                     file.original = this.project.input.firstSourceFile;
                     file.sourceMapOrigins = this.project.input.getFileNames(true).map(function (fName) { return _this.project.input.getFile(fName); });
                 }


### PR DESCRIPTION
I like the idea to specify single file, lets say, `main.js` in `gulp.src` and compile all dependant modules along with it.
It seems to be reasonable behaviour when option `noExternalResolve` is turned off.

For example, if my main.ts requires some module:
```javascript
// main.ts
import thing from "./somemodule";
```

id like to simply specify in gulpfile:
```javascript
...
    return gulp.src([
       './src/scripts/main.ts'
    ])
        .pipe(typeScript({ module: "commonjs" }))
...
```
and get 2 compiled files — `main.js` and `somemodule.js`