### PR TITLE
Make sourcemap 'file' property relative to file.base

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -102,6 +102,10 @@ export class Output {
 						file.skipPush = !file.original.gulp;
 						file.sourceMapOrigins = [file.original];
 					}
+					// Fix the output filename in the source map, which must be relative
+					// to the source root or it won't work correctly in gulp-sourcemaps if
+					// there are more transformations down in the pipeline.
+					file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, originalFileName).replace(/\.ts$/, '.js');
 				}
 
 				this.applySourceMaps(file);


### PR DESCRIPTION
From gulp-sourcemaps [documentation](https://github.com/floridoo/gulp-sourcemaps#plugin-developers-only-how-to-add-source-map-support-to-plugins):

> Important: Make sure the paths in the generated source map (file and sources)
are relative to file.base (e.g. use file.relative)

Fix the "file" property to meet the above requirement(before this commit only
"sources" are relative to file.base).