### PR TITLE
Enable to work ModuleResolution option.

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -125,12 +125,12 @@ function getModuleKind(typescript: typeof ts, moduleName: string) {
 }
 
 function getModuleResolution(typescript: typeof ts, kind: string) {
-	if ((<any> typescript).ModuleResolution === undefined) {
+	if ((<any> typescript).ModuleResolutionKind === undefined) {
 		return undefined; // Not supported in TS1.4 & 1.5
 	}
 	// Enum member name is NodeJs, while option name is `node`
 	if (kind === 'node') kind = 'nodejs';
-	const map: utils.Map<number> = createEnumMap((<any> typescript).ModuleResolution);
+	const map: utils.Map<number> = createEnumMap((<any> typescript).ModuleResolutionKind);
 	return map[kind.toLowerCase()];
 }
 
@@ -248,7 +248,7 @@ module compile {
 		isolatedModules?: boolean;
 
 		rootDir?: string; // Only supported when using tsProject.src(). If you're not using tsProject.src, use base option of gulp.src instead.
-		
+
 		// Unsupported by gulp-typescript
 		sourceRoot?: string; // Use sourceRoot in gulp-sourcemaps instead
 	}
@@ -287,13 +287,13 @@ module compile {
 		}
 
 		const project = new Project(tsConfigFileName, tsConfigContent, getCompilerOptions(settings), settings.noExternalResolve ? true : false, settings.sortOutput ? true : false, settings.typescript);
-		
+
 		// Isolated modules are only supported when using TS1.5+
 		if (project.options['isolatedModules'] && !tsApi.isTS14(project.typescript)) {
 			if (project.options.out !== undefined || project.options['outFile'] !== undefined || project.sortOutput) {
 				console.warn('You cannot combine option `isolatedModules` with `out`, `outFile` or `sortOutput`');
 			}
-			
+
 			project.options.sourceMap = false;
 			project.options.declaration = false;
 			project.options['inlineSourceMap'] = true;
@@ -301,7 +301,7 @@ module compile {
 		} else {
 			project.compiler = new compiler.ProjectCompiler();
 		}
-		
+
 		return project;
 	}
 

--- a/lib/tsapi.ts
+++ b/lib/tsapi.ts
@@ -60,7 +60,7 @@ export function isTS14(typescript: typeof ts) {
 	return !('findConfigFile' in typescript);
 }
 export function isTS16OrNewer(typescript: typeof ts) {
-	return !('ModuleResolution' in typescript);
+	return !('ModuleResolutionKind' in typescript);
 }
 
 export function getFileName(thing: { filename: string} | { fileName: string }): string {
@@ -69,10 +69,10 @@ export function getFileName(thing: { filename: string} | { fileName: string }): 
 }
 export function getDiagnosticsAndEmit(program: Program14 | Program15): [ts.Diagnostic[], CompilationResult] {
 	let result = emptyCompilationResult();
-	
+
 	if ((<Program14> program).getDiagnostics) { // TS 1.4
 		let errors = (<Program14> program).getDiagnostics();
-		
+
 		result.syntaxErrors = errors.length;
 
 		if (!errors.length) {
@@ -95,14 +95,14 @@ export function getDiagnosticsAndEmit(program: Program14 | Program15): [ts.Diagn
 		result.syntaxErrors = errors.length;
 		if (errors.length === 0) {
 			errors = (<Program15> program).getGlobalDiagnostics();
-			
+
 			// Remove error: "File '...' is not under 'rootDir' '...'. 'rootDir' is expected to contain all source files."
 			// This is handled by ICompiler#correctSourceMap, so this error can be muted.
 			errors = errors.filter((item) => item.code !== 6059);
-			
+
 			result.globalErrors = errors.length;
 		}
-		
+
 		if (errors.length === 0) {
 			errors = (<Program15> program).getSemanticDiagnostics();
 			result.semanticErrors = errors.length;
@@ -144,6 +144,6 @@ export function transpile(typescript: TypeScript14 | TypeScript15, input: string
 	if (!(<TypeScript15> typescript).transpile) {
 		throw new Error('gulp-typescript: Single file compilation is not supported using TypeScript 1.4');
 	}
-	
+
 	return (<TypeScript15> typescript).transpile(input, compilerOptions, fileName.replace(/\\/g, '/'), diagnostics);
 }


### PR DESCRIPTION
When I use the `gulp-typescript`, `ModuleResolution` option doesn't work at my TypeScript project(https://github.com/pocke/brainfuck-playground).
Because, `typescript.ModuleResolution` doesn't exist. However, `ModuleResolutionKind` exists instead of `ModuleResolution`.



I don't know how to build.
Because, can't find typescript module... 

error log

```
$ gulp
[13:04:21] Using gulpfile ~/ghq/github.com/ivogabe/gulp-typescript/gulpfile.js
[13:04:21] Starting 'clean'...
[13:04:21] Starting 'typecheck-1.4'...
[13:04:21] 'typecheck-1.4' errored after 419 μs
[13:04:21] Error: Cannot find module './typescript/1-4'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.require.resolve (module.js:388:19)
    at findTSDefinition (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/gulpfile.js:20:40)
    at Gulp.<anonymous> (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/gulpfile.js:67:3)
    at module.exports (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/node_modules/gulp/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/node_modules/gulp/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/home/pocke/ghq/github.com/ivogabe/gulp-typescript/node_modules/gulp/node_modules/orchestrator/index.js:134:8)
    at /usr/lib/node_modules/gulp/bin/gulp.js:129:20
    at process._tickCallback (node.js:355:11)
[13:04:21] Finished 'clean' after 4.87 ms
```

If I should build, please tell me how to build.