### PR TITLE
Add `useCaseSensitiveFileNames` option

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -73,7 +73,8 @@ export class ProjectCompiler implements ICompiler {
 			this.project.currentDirectory,
 			this.project.input,
 			!this.project.noExternalResolve,
-			this.project.options.target >= ts.ScriptTarget.ES6 ? 'lib.es6.d.ts' : 'lib.d.ts'
+			this.project.options.target >= ts.ScriptTarget.ES6 ? 'lib.es6.d.ts' : 'lib.d.ts',
+			this.project.useCaseSensitiveFileNames
 		);
 
 		let rootFilenames: string[] = this.project.input.getFileNames(true);

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -40,7 +40,9 @@ export class Host implements ts.CompilerHost {
 	input: FileCache;
 	output: utils.Map<string>;
 
-	constructor(typescript: typeof ts, currentDirectory: string, input: FileCache, externalResolve: boolean, libFileName: string) {
+	private shouldUseCaseSensitiveFileNames: boolean;
+
+	constructor(typescript: typeof ts, currentDirectory: string, input: FileCache, externalResolve: boolean, libFileName: string, shouldUseCaseSensitiveFileNames: boolean) {
 		this.typescript = typescript;
 
 		this.currentDirectory = currentDirectory;
@@ -48,6 +50,8 @@ export class Host implements ts.CompilerHost {
 
 		this.externalResolve = externalResolve;
 		this.libFileName = libFileName;
+
+		this.shouldUseCaseSensitiveFileNames = shouldUseCaseSensitiveFileNames;
 
 		this.reset();
 	}
@@ -59,8 +63,9 @@ export class Host implements ts.CompilerHost {
 	getNewLine() {
 		return '\n';
 	}
+
 	useCaseSensitiveFileNames() {
-		return false;
+		return this.shouldUseCaseSensitiveFileNames;
 	}
 
 	getCurrentDirectory = () => {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -63,7 +63,16 @@ export class Project {
 
 	currentDirectory: string;
 
-	constructor(configFileName: string, config: TsConfig, options: ts.CompilerOptions, noExternalResolve: boolean, sortOutput: boolean, typescript = ts) {
+	useCaseSensitiveFileNames: boolean;
+
+		constructor(
+				configFileName: string,
+				config: TsConfig,
+				options: ts.CompilerOptions,
+				noExternalResolve: boolean,
+				sortOutput: boolean,
+				typescript = ts,
+				useCaseSensitiveFileNames: boolean = false) {
 		this.typescript = typescript;
 		this.configFileName = configFileName;
 		this.config = config;
@@ -74,6 +83,8 @@ export class Project {
 		this.singleOutput = options.out !== undefined || options['outFile'] !== undefined;
 
 		this.input = new FileCache(typescript, options);
+
+		this.useCaseSensitiveFileNames = useCaseSensitiveFileNames;
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ Besides the official options options, gulp-typescript supports the following opt
 - ```noExternalResolve``` (boolean) - Do not resolve files that are not in the input. Explanation below.
 - ```sortOutput``` (boolean) - Sort output files. Useful if you want to concatenate files (see below).
 - ```typescript``` (object) - Use a different version / fork of TypeScript (see below). Use it like: `typescript: require('typescript')` or `typescript: require('my-fork-of-typescript')`
+- ```useCaseSensitiveFileNames``` (boolean) - Specify whether you want the typescript compiler to handle files case-sensitively.
 
 Basic Usage
 ----------

--- a/release/compiler.js
+++ b/release/compiler.js
@@ -43,7 +43,7 @@ var ProjectCompiler = (function () {
         }
         var root = this.project.input.commonBasePath;
         this.project.options.sourceRoot = root;
-        this.host = new host_1.Host(this.project.typescript, this.project.currentDirectory, this.project.input, !this.project.noExternalResolve, this.project.options.target >= 2 /* ES6 */ ? 'lib.es6.d.ts' : 'lib.d.ts');
+        this.host = new host_1.Host(this.project.typescript, this.project.currentDirectory, this.project.input, !this.project.noExternalResolve, this.project.options.target >= 2 /* ES6 */ ? 'lib.es6.d.ts' : 'lib.d.ts', this.project.useCaseSensitiveFileNames);
         var rootFilenames = this.project.input.getFileNames(true);
         if (this.project.filterSettings !== undefined) {
             var filter = new filter_1.Filter(this.project, this.project.filterSettings);

--- a/release/host.js
+++ b/release/host.js
@@ -4,7 +4,7 @@ var utils = require('./utils');
 var fs = require('fs');
 var path = require('path');
 var Host = (function () {
-    function Host(typescript, currentDirectory, input, externalResolve, libFileName) {
+    function Host(typescript, currentDirectory, input, externalResolve, libFileName, shouldUseCaseSensitiveFileNames) {
         var _this = this;
         this.getCurrentDirectory = function () {
             return _this.currentDirectory;
@@ -38,6 +38,7 @@ var Host = (function () {
         this.input = input;
         this.externalResolve = externalResolve;
         this.libFileName = libFileName;
+        this.shouldUseCaseSensitiveFileNames = shouldUseCaseSensitiveFileNames;
         this.reset();
     }
     Host.getLibDefault = function (typescript, libFileName) {
@@ -66,7 +67,7 @@ var Host = (function () {
         return '\n';
     };
     Host.prototype.useCaseSensitiveFileNames = function () {
-        return false;
+        return this.shouldUseCaseSensitiveFileNames;
     };
     Host.prototype.getCanonicalFileName = function (filename) {
         return utils.normalizePath(filename);

--- a/release/project.js
+++ b/release/project.js
@@ -8,8 +8,9 @@ var utils = require('./utils');
 var input_1 = require('./input');
 var output_1 = require('./output');
 var Project = (function () {
-    function Project(configFileName, config, options, noExternalResolve, sortOutput, typescript) {
+    function Project(configFileName, config, options, noExternalResolve, sortOutput, typescript, useCaseSensitiveFileNames) {
         if (typescript === void 0) { typescript = ts; }
+        if (useCaseSensitiveFileNames === void 0) { useCaseSensitiveFileNames = false; }
         this.typescript = typescript;
         this.configFileName = configFileName;
         this.config = config;
@@ -18,6 +19,7 @@ var Project = (function () {
         this.sortOutput = sortOutput;
         this.singleOutput = options.out !== undefined || options['outFile'] !== undefined;
         this.input = new input_1.FileCache(typescript, options);
+        this.useCaseSensitiveFileNames = useCaseSensitiveFileNames;
     }
     /**
      * Resets the compiler.


### PR DESCRIPTION
Allow the gulp consumer to specify whether or not to use case-sensitive file names.