### PR TITLE
isolatedModules option doesnt work with outDir

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -296,6 +296,7 @@ module compile {
 
 			project.options.sourceMap = false;
 			project.options.declaration = false;
+			delete project.options.outDir;
 			project.options['inlineSourceMap'] = true;
 			project.compiler = new compiler.FileCompiler();
 		} else {


### PR DESCRIPTION
Having outDir in my tsconfig.json breaks isolatedModules switch. No output is emitted. Deleting outDir fixes it.