### PR TITLE
Fix bug when filtering reference in parent dir

### DIFF
--- a/lib/filter.ts
+++ b/lib/filter.ts
@@ -58,7 +58,7 @@ export class Filter {
 				process.cwd(),
 				file.gulp.base
 			) + '/';
-			if (file.gulp.path.substring(base.length) === searchFileName) {
+			if (path.resolve(base, searchFileName) === file.gulp.path) {
 				return file;
 			}
 		}

--- a/release/filter.js
+++ b/release/filter.js
@@ -48,7 +48,7 @@ var Filter = (function () {
             if (!file || !file.gulp)
                 continue;
             var base = path.resolve(process.cwd(), file.gulp.base) + '/';
-            if (file.gulp.path.substring(base.length) === searchFileName) {
+            if (path.resolve(base, searchFileName) === file.gulp.path) {
                 return file;
             }
         }


### PR DESCRIPTION
This fixes a bug where gulp-typescript fails to find a file listed in the `referencedFrom` filter list if that file lives in a parent directory of the gulpfile, e.g.:

```javascript
gulp.src(['files/**/*.ts', '../lib/**/*.ts'])
  .pipe(ts.filter(project, { referencedFrom: ['../lib/test.ts'] }))
  .pipe(gulp.dest('./dist'))
```