### PR TITLE
WIP: enable typescript@next path mapping

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -1,0 +1,243 @@
+"use strict";
+var path = require('path');
+var tsApi = require('./tsapi');
+var utils = require('./utils');
+var pathIsAbsolute = require('path-is-absolute');
+(function (FileChangeState) {
+    FileChangeState[FileChangeState["New"] = 0] = "New";
+    FileChangeState[FileChangeState["Equal"] = 1] = "Equal";
+    FileChangeState[FileChangeState["Modified"] = 2] = "Modified";
+    FileChangeState[FileChangeState["Deleted"] = 3] = "Deleted";
+    FileChangeState[FileChangeState["NotFound"] = 4] = "NotFound";
+})(exports.FileChangeState || (exports.FileChangeState = {}));
+var FileChangeState = exports.FileChangeState;
+(function (FileKind) {
+    FileKind[FileKind["Source"] = 0] = "Source";
+    FileKind[FileKind["Config"] = 1] = "Config";
+})(exports.FileKind || (exports.FileKind = {}));
+var FileKind = exports.FileKind;
+var File;
+(function (File) {
+    function fromContent(fileName, content) {
+        var kind = FileKind.Source;
+        if (path.extname(fileName).toLowerCase() === 'json')
+            kind = FileKind.Config;
+        return {
+            fileNameNormalized: utils.normalizePath(fileName),
+            fileNameOriginal: fileName,
+            content: content,
+            kind: kind
+        };
+    }
+    File.fromContent = fromContent;
+    function fromGulp(file) {
+        var str = file.contents.toString('utf8');
+        var data = fromContent(file.path, str);
+        data.gulp = file;
+        return data;
+    }
+    File.fromGulp = fromGulp;
+    function equal(a, b) {
+        if (a === undefined || b === undefined)
+            return a === b;
+        return (a.fileNameOriginal === b.fileNameOriginal)
+            && (a.content === b.content);
+    }
+    File.equal = equal;
+    function getChangeState(previous, current) {
+        if (previous === undefined) {
+            return current === undefined ? FileChangeState.NotFound : FileChangeState.New;
+        }
+        if (current === undefined) {
+            return FileChangeState.Deleted;
+        }
+        if (equal(previous, current)) {
+            return FileChangeState.Equal;
+        }
+        return FileChangeState.Modified;
+    }
+    File.getChangeState = getChangeState;
+})(File = exports.File || (exports.File = {}));
+var FileDictionary = (function () {
+    function FileDictionary(typescript) {
+        this.files = {};
+        this.firstSourceFile = undefined;
+        this.typescript = typescript;
+    }
+    FileDictionary.prototype.addGulp = function (gFile) {
+        return this.addFile(File.fromGulp(gFile));
+    };
+    FileDictionary.prototype.addContent = function (fileName, content) {
+        return this.addFile(File.fromContent(fileName, content));
+    };
+    FileDictionary.prototype.addFile = function (file) {
+        if (file.kind === FileKind.Source) {
+            this.initTypeScriptSourceFile(file);
+            if (!this.firstSourceFile)
+                this.firstSourceFile = file;
+        }
+        this.files[file.fileNameNormalized] = file;
+        return file;
+    };
+    FileDictionary.prototype.getFile = function (name) {
+        return this.files[utils.normalizePath(name)];
+    };
+    FileDictionary.prototype.getFileNames = function (onlyGulp) {
+        if (onlyGulp === void 0) { onlyGulp = false; }
+        var fileNames = [];
+        for (var fileName in this.files) {
+            if (!this.files.hasOwnProperty(fileName))
+                continue;
+            var file = this.files[fileName];
+            if (onlyGulp && !file.gulp)
+                continue;
+            fileNames.push(file.fileNameOriginal);
+        }
+        return fileNames;
+    };
+    FileDictionary.prototype.getSourceFileNames = function (onlyGulp) {
+        var fileNames = this.getFileNames(onlyGulp);
+        var sourceFileNames = fileNames
+            .filter(function (fileName) { return fileName.substr(fileName.length - 5).toLowerCase() !== '.d.ts'; });
+        if (sourceFileNames.length === 0) {
+            return fileNames;
+        }
+        return sourceFileNames;
+    };
+    Object.defineProperty(FileDictionary.prototype, "commonBasePath", {
+        get: function () {
+            var _this = this;
+            var fileNames = this.getSourceFileNames(true);
+            return utils.getCommonBasePathOfArray(fileNames.map(function (fileName) {
+                var file = _this.files[utils.normalizePath(fileName)];
+                return path.resolve(process.cwd(), file.gulp.base);
+            }));
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(FileDictionary.prototype, "commonSourceDirectory", {
+        get: function () {
+            var _this = this;
+            var fileNames = this.getSourceFileNames();
+            return utils.getCommonBasePathOfArray(fileNames.map(function (fileName) {
+                var file = _this.files[utils.normalizePath(fileName)];
+                return path.dirname(file.fileNameNormalized);
+            }));
+        },
+        enumerable: true,
+        configurable: true
+    });
+    return FileDictionary;
+}());
+exports.FileDictionary = FileDictionary;
+var FileCache = (function () {
+    function FileCache(typescript, options) {
+        this.previous = undefined;
+        this.noParse = false;
+        this.version = 0;
+        this.typescript = typescript;
+        this.options = options;
+        this.createDictionary();
+    }
+    FileCache.prototype.getCommonBasePath = function () {
+        if (!this._commonBasePath) {
+            this._commonBasePath = this.current.commonBasePath;
+        }
+        return this._commonBasePath;
+    };
+    FileCache.prototype.addGulp = function (gFile) {
+        return this.current.addGulp(gFile);
+    };
+    FileCache.prototype.addContent = function (fileName, content) {
+        return this.current.addContent(fileName, content);
+    };
+    FileCache.prototype.reset = function () {
+        this.version++;
+        this.previous = this.current;
+        this.createDictionary();
+    };
+    FileCache.prototype.createDictionary = function () {
+        var _this = this;
+        this.current = new FileDictionary(this.typescript);
+        this.current.initTypeScriptSourceFile = function (file) { return _this.initTypeScriptSourceFile(file); };
+    };
+    FileCache.prototype.initTypeScriptSourceFile = function (file) {
+        if (this.noParse)
+            return;
+        if (this.previous) {
+            var previous = this.previous.getFile(file.fileNameOriginal);
+            if (File.equal(previous, file)) {
+                file.ts = previous.ts;
+                return;
+            }
+        }
+        file.ts = tsApi.createSourceFile(this.typescript, file.fileNameOriginal, file.content, this.options.target, this.version + '');
+    };
+    FileCache.prototype.getFile = function (name) {
+        if (pathIsAbsolute(name)) {
+            return this.current.getFile(name);
+        }
+        else {
+            return this.current.getFile(path.resolve(this.getCommonBasePath(), name));
+        }
+    };
+    FileCache.prototype.getFileChange = function (name) {
+        var previous;
+        if (this.previous) {
+            previous = this.previous.getFile(name);
+        }
+        var current = this.current.getFile(name);
+        return {
+            previous: previous,
+            current: current,
+            state: File.getChangeState(previous, current)
+        };
+    };
+    FileCache.prototype.getFileNames = function (onlyGulp) {
+        if (onlyGulp === void 0) { onlyGulp = false; }
+        return this.current.getFileNames(onlyGulp);
+    };
+    Object.defineProperty(FileCache.prototype, "firstSourceFile", {
+        get: function () {
+            return this.current.firstSourceFile;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(FileCache.prototype, "commonBasePath", {
+        get: function () {
+            return this.current.commonBasePath;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(FileCache.prototype, "commonSourceDirectory", {
+        get: function () {
+            return this.current.commonSourceDirectory;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    FileCache.prototype.isChanged = function (onlyGulp) {
+        if (onlyGulp === void 0) { onlyGulp = false; }
+        if (!this.previous)
+            return true;
+        var files = this.getFileNames(onlyGulp);
+        var oldFiles = this.previous.getFileNames(onlyGulp);
+        if (files.length !== oldFiles.length)
+            return true;
+        for (var fileName in files) {
+            if (oldFiles.indexOf(fileName) === -1)
+                return true;
+        }
+        for (var fileName in files) {
+            var change = this.getFileChange(fileName);
+            if (change.state !== FileChangeState.Equal)
+                return true;
+        }
+        return false;
+    };
+    return FileCache;
+}());
+exports.FileCache = FileCache;

--- a/lib/input.ts
+++ b/lib/input.ts
@@ -7,6 +7,8 @@ import * as tsApi from './tsapi';
 import * as utils from './utils';
 import { VinylFile } from './vinyl-file';
 
+const pathIsAbsolute = require('path-is-absolute')
+
 export enum FileChangeState {
 	New,
 	Equal,
@@ -112,12 +114,12 @@ export class FileDictionary {
 		}
 		return fileNames;
 	}
-	
+
 	private getSourceFileNames(onlyGulp?: boolean) {
 		const fileNames = this.getFileNames(onlyGulp);
 		const sourceFileNames = fileNames
 			.filter(fileName => fileName.substr(fileName.length - 5).toLowerCase() !== '.d.ts');
-		
+
 		if (sourceFileNames.length === 0) {
 			// Only definition files, so we will calculate the common base path based on the
 			// paths of the definition files.
@@ -125,7 +127,7 @@ export class FileDictionary {
 		}
 		return sourceFileNames;
 	}
-	
+
 	get commonBasePath() {
 		const fileNames = this.getSourceFileNames(true);
 		return utils.getCommonBasePathOfArray(
@@ -154,15 +156,15 @@ export class FileCache {
 
 	typescript: typeof ts;
 	version: number = 0;
-  _commonBasePath: string;
+	_commonBasePath: string;
 
 
-  private getCommonBasePath() {
-    if (!this._commonBasePath) {
-      this._commonBasePath = this.current.commonBasePath;
-    }
-    return this._commonBasePath;
-  }
+	private getCommonBasePath() {
+		if (!this._commonBasePath) {
+			this._commonBasePath = this.current.commonBasePath;
+		}
+		return this._commonBasePath;
+	}
 
 	constructor(typescript: typeof ts, options: ts.CompilerOptions) {
 		this.typescript = typescript;
@@ -201,13 +203,12 @@ export class FileCache {
 	}
 
 	getFile(name: string) {
-    if (/^\//.test(name)) {
-		return this.current.getFile(name);
-    }
-    else {
-      let file = this.current.getFile(path.resolve(this.getCommonBasePath(), name));
-      return file
-    }
+		if (pathIsAbsolute(name)) {
+			return this.current.getFile(name);
+		}
+		else {
+			return this.current.getFile(path.resolve(this.getCommonBasePath(), name));
+		}
 	}
 
 	getFileChange(name: string): FileChange {

--- a/lib/input.ts
+++ b/lib/input.ts
@@ -154,6 +154,15 @@ export class FileCache {
 
 	typescript: typeof ts;
 	version: number = 0;
+  _commonBasePath: string;
+
+
+  private getCommonBasePath() {
+    if (!this._commonBasePath) {
+      this._commonBasePath = this.current.commonBasePath;
+    }
+    return this._commonBasePath;
+  }
 
 	constructor(typescript: typeof ts, options: ts.CompilerOptions) {
 		this.typescript = typescript;
@@ -192,7 +201,13 @@ export class FileCache {
 	}
 
 	getFile(name: string) {
+    if (/^\//.test(name)) {
 		return this.current.getFile(name);
+    }
+    else {
+      let file = this.current.getFile(path.resolve(this.getCommonBasePath(), name));
+      return file
+    }
 	}
 
 	getFileChange(name: string): FileChange {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,234 @@
+"use strict";
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var ts = require('typescript');
+var fs = require('fs');
+var gutil = require('gulp-util');
+var stream = require('stream');
+var project = require('./project');
+var _filter = require('./filter');
+var _reporter = require('./reporter');
+var compiler = require('./compiler');
+var tsApi = require('./tsapi');
+var through2 = require('through2');
+var PLUGIN_NAME = 'gulp-typescript';
+var CompileStream = (function (_super) {
+    __extends(CompileStream, _super);
+    function CompileStream(proj) {
+        _super.call(this, { objectMode: true });
+        this.dts = new CompileOutputStream();
+        this.project = proj;
+        this.js = this;
+        this.on('error', function () { });
+    }
+    CompileStream.prototype._write = function (file, encoding, cb) {
+        if (cb === void 0) { cb = function (err) { }; }
+        if (!file)
+            return cb();
+        if (file.isNull()) {
+            cb();
+            return;
+        }
+        if (file.isStream()) {
+            return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+        }
+        var isFirstFile = this.project.input.firstSourceFile === undefined;
+        var inputFile = this.project.input.addGulp(file);
+        if (isFirstFile) {
+            this.project.currentDirectory = this.project.input.firstSourceFile.gulp.cwd;
+        }
+        this.project.compiler.inputFile(inputFile);
+        cb();
+    };
+    CompileStream.prototype._read = function () {
+    };
+    CompileStream.prototype.end = function (chunk, encoding, callback) {
+        this._write(chunk, encoding, callback);
+        this.project.compiler.inputDone();
+    };
+    return CompileStream;
+}(stream.Duplex));
+var CompileOutputStream = (function (_super) {
+    __extends(CompileOutputStream, _super);
+    function CompileOutputStream() {
+        _super.call(this, { objectMode: true });
+    }
+    CompileOutputStream.prototype._read = function () {
+    };
+    return CompileOutputStream;
+}(stream.Readable));
+function compile(param, filters, theReporter) {
+    var proj;
+    if (param instanceof project.Project) {
+        proj = param;
+    }
+    else {
+        proj = compile.createProject(param || {});
+    }
+    var inputStream = new CompileStream(proj);
+    proj.reset(inputStream.js, inputStream.dts);
+    proj.filterSettings = filters;
+    proj.reporter = theReporter || _reporter.defaultReporter();
+    proj.compiler.prepare(proj);
+    return inputStream;
+}
+function createEnumMap(input) {
+    var map = {};
+    var keys = Object.keys(input);
+    for (var _i = 0, keys_1 = keys; _i < keys_1.length; _i++) {
+        var key = keys_1[_i];
+        var value = input[key];
+        if (typeof value === 'number') {
+            map[key.toLowerCase()] = value;
+        }
+    }
+    return map;
+}
+function getScriptTarget(typescript, language) {
+    var map = createEnumMap(typescript.ScriptTarget);
+    return map[language.toLowerCase()];
+}
+function getModuleKind(typescript, moduleName) {
+    var map = createEnumMap(typescript.ModuleKind);
+    return map[moduleName.toLowerCase()];
+}
+function getModuleResolution(typescript, kind) {
+    if (typescript.ModuleResolutionKind === undefined) {
+        return undefined;
+    }
+    if (kind === 'node')
+        kind = 'nodejs';
+    var map = createEnumMap(typescript.ModuleResolutionKind);
+    return map[kind.toLowerCase()];
+}
+function getJsxEmit(typescript, jsx) {
+    if (typescript.JsxEmit === undefined) {
+        return undefined;
+    }
+    var map = createEnumMap(typescript.JsxEmit);
+    return map[jsx.toLowerCase()];
+}
+function getCompilerOptions(settings) {
+    var tsSettings = {};
+    var typescript = settings.typescript || ts;
+    for (var key in settings) {
+        if (!Object.hasOwnProperty.call(settings, key))
+            continue;
+        if (key === 'noExternalResolve' ||
+            key === 'declarationFiles' ||
+            key === 'sortOutput' ||
+            key === 'typescript' ||
+            key === 'target' ||
+            key === 'module' ||
+            key === 'moduleResolution' ||
+            key === 'jsx' ||
+            key === 'sourceRoot' ||
+            key === 'rootDir' ||
+            key === 'sourceMap' ||
+            key === 'inlineSourceMap')
+            continue;
+        tsSettings[key] = settings[key];
+    }
+    if (typeof settings.target === 'string') {
+        tsSettings.target = getScriptTarget(typescript, settings.target);
+    }
+    else if (typeof settings.target === 'number') {
+        tsSettings.target = settings.target;
+    }
+    if (typeof settings.module === 'string') {
+        tsSettings.module = getModuleKind(typescript, settings.module);
+    }
+    else if (typeof settings.module === 'number') {
+        tsSettings.module = settings.module;
+    }
+    if (typeof settings.jsx === 'string') {
+        tsSettings['jsx'] = getJsxEmit(typescript, settings.jsx);
+    }
+    else if (typeof settings.jsx === 'number') {
+        tsSettings['jsx'] = settings.jsx;
+    }
+    if (typeof settings.moduleResolution === 'string') {
+        tsSettings['moduleResolution'] = getModuleResolution(typescript, settings.moduleResolution);
+    }
+    else if (typeof settings.moduleResolution === 'number') {
+        tsSettings['moduleResolution'] = settings.moduleResolution;
+    }
+    if (tsSettings.target === undefined) {
+        tsSettings.target = 0;
+    }
+    if (tsSettings.module === undefined) {
+        tsSettings.module = 0;
+    }
+    if (settings.sourceRoot !== undefined) {
+        console.warn('gulp-typescript: sourceRoot isn\'t supported any more. Use sourceRoot option of gulp-sourcemaps instead.');
+    }
+    if (settings.declarationFiles !== undefined) {
+        tsSettings.declaration = settings.declarationFiles;
+    }
+    tsSettings.sourceMap = true;
+    return tsSettings;
+}
+var compile;
+(function (compile) {
+    compile.Project = project.Project;
+    compile.reporter = _reporter;
+    function createProject(fileNameOrSettings, settings) {
+        var tsConfigFileName = undefined;
+        var tsConfigContent = undefined;
+        if (fileNameOrSettings !== undefined) {
+            if (typeof fileNameOrSettings === 'string') {
+                tsConfigFileName = fileNameOrSettings;
+                var tsConfigText = fs.readFileSync(fileNameOrSettings).toString();
+                tsConfigContent = JSON.parse(tsConfigText.replace(/^\uFEFF/, ''));
+                var newSettings = {};
+                if (tsConfigContent.compilerOptions) {
+                    for (var _i = 0, _a = Object.keys(tsConfigContent.compilerOptions); _i < _a.length; _i++) {
+                        var key = _a[_i];
+                        newSettings[key] = tsConfigContent.compilerOptions[key];
+                    }
+                }
+                if (settings) {
+                    for (var _b = 0, _c = Object.keys(settings); _b < _c.length; _b++) {
+                        var key = _c[_b];
+                        newSettings[key] = settings[key];
+                    }
+                }
+                settings = newSettings;
+            }
+            else {
+                settings = fileNameOrSettings;
+            }
+        }
+        var project = new compile.Project(tsConfigFileName, tsConfigContent, getCompilerOptions(settings), settings.noExternalResolve ? true : false, settings.sortOutput ? true : false, settings.typescript);
+        if (project.options['isolatedModules'] && !tsApi.isTS14(project.typescript)) {
+            if (project.options.out !== undefined || project.options['outFile'] !== undefined || project.sortOutput) {
+                console.warn('You cannot combine option `isolatedModules` with `out`, `outFile` or `sortOutput`');
+            }
+            project.options.sourceMap = false;
+            project.options.declaration = false;
+            project.options['inlineSourceMap'] = true;
+            project.compiler = new compiler.FileCompiler();
+        }
+        else {
+            project.compiler = new compiler.ProjectCompiler();
+        }
+        return project;
+    }
+    compile.createProject = createProject;
+    function filter(project, filters) {
+        var filterObj = undefined;
+        return through2.obj(function (file, encoding, callback) {
+            if (!filterObj) {
+                filterObj = new _filter.Filter(project, filters);
+            }
+            if (filterObj.match(file.path))
+                this.push(file);
+            callback();
+        });
+    }
+    compile.filter = filter;
+})(compile || (compile = {}));
+module.exports = compile;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -236,6 +236,11 @@ module compile {
 		target: string | ts.ScriptTarget;
 		module: string | ts.ModuleKind;
 		moduleResolution: string | number;
+
+    paths: any;
+    baseUrl: string;
+    rootDirs: any;
+
 		jsx: string | number;
 
 		declarationFiles?: boolean;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -237,9 +237,9 @@ module compile {
 		module: string | ts.ModuleKind;
 		moduleResolution: string | number;
 
-    paths: any;
-    baseUrl: string;
-    rootDirs: any;
+		paths: any;
+		baseUrl: string;
+		rootDirs: any;
 
 		jsx: string | number;
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "main": "release/main.js",
   "dependencies": {
     "gulp-util": "~3.0.7",
+    "path-is-absolute": "^1.0.0",
     "source-map": "~0.5.3",
     "through2": "~2.0.0",
     "typescript": "1.7.5",

--- a/release/input.js
+++ b/release/input.js
@@ -2,6 +2,7 @@
 var path = require('path');
 var tsApi = require('./tsapi');
 var utils = require('./utils');
+var pathIsAbsolute = require('path-is-absolute');
 (function (FileChangeState) {
     FileChangeState[FileChangeState["New"] = 0] = "New";
     FileChangeState[FileChangeState["Equal"] = 1] = "Equal";
@@ -176,12 +177,11 @@ var FileCache = (function () {
         file.ts = tsApi.createSourceFile(this.typescript, file.fileNameOriginal, file.content, this.options.target, this.version + '');
     };
     FileCache.prototype.getFile = function (name) {
-        if (/^\//.test(name)) {
+        if (pathIsAbsolute(name)) {
             return this.current.getFile(name);
         }
         else {
-            var file = this.current.getFile(path.resolve(this.getCommonBasePath(), name));
-            return file;
+            return this.current.getFile(path.resolve(this.getCommonBasePath(), name));
         }
     };
     FileCache.prototype.getFileChange = function (name) {

--- a/release/input.js
+++ b/release/input.js
@@ -141,6 +141,12 @@ var FileCache = (function () {
         this.options = options;
         this.createDictionary();
     }
+    FileCache.prototype.getCommonBasePath = function () {
+        if (!this._commonBasePath) {
+            this._commonBasePath = this.current.commonBasePath;
+        }
+        return this._commonBasePath;
+    };
     FileCache.prototype.addGulp = function (gFile) {
         return this.current.addGulp(gFile);
     };
@@ -170,7 +176,13 @@ var FileCache = (function () {
         file.ts = tsApi.createSourceFile(this.typescript, file.fileNameOriginal, file.content, this.options.target, this.version + '');
     };
     FileCache.prototype.getFile = function (name) {
-        return this.current.getFile(name);
+        if (/^\//.test(name)) {
+            return this.current.getFile(name);
+        }
+        else {
+            var file = this.current.getFile(path.resolve(this.getCommonBasePath(), name));
+            return file;
+        }
     };
     FileCache.prototype.getFileChange = function (name) {
         var previous;


### PR DESCRIPTION
This isn't really a pull request, in that I know my "solution" is far from ready for prime time, but I thought I'd throw this up here in case anyone wants to take the ball and run with it toward a real implementation.

See [Path mappings based module resolution](https://github.com/Microsoft/TypeScript/issues/5039).

This is a hack to make it possible to use the `baseUrl` property
in typescript@next. The `paths` object property probably also works, too.
Less confident about the `rootDirs` array property.

I believe that baseUrl is to be interpreted as from the directory
where tsconfig.json lives, and this isn't generally avaialable in
gulp-typescript's API, so one reason (among many) that this is a
hack and not a solution is that it assumes the directory found to
be the 'commonBasePath' is assumed to be the tsconfig file's
directory, which may not always be the case.