### PR TITLE
Set typescript as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "gulp-util": "~3.0.7",
     "source-map": "~0.5.3",
     "through2": "~2.0.0",
-    "typescript": "1.7.5",
     "vinyl-fs": "~2.2.1"
   },
   "devDependencies": {
@@ -72,6 +71,9 @@
   },
   "scripts": {
     "test": "gulp"
+  },
+  "peerDependencies": {
+    "typescript": ">=1.7.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This way we don't depend on gulp-typescript to be updated each time a new TypeScript version is released, we can choose the exact version we want and we don't get it installed twice (which causes awkward moments like "why does it work in console but not in gulp-typescript?".)

Cheers. :smiley: 