### PR TITLE
Let tests pass on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,6 +123,18 @@ function runTest(name, callback) {
 			var finishInfo;
 			var reporter = {
 				error: function(err) {
+					if (path.sep === '\\') { //filenames embedded in error output contain OS-dependent path separators
+						var colon = err.message.indexOf(":");
+						if (colon === -1 || !err.diagnostic || err.message.indexOf(path.sep) === -1) {
+							return;
+						}
+
+						var fileName = err.message.slice(0, colon);
+						var detail = err.message.slice(colon);
+						fileName = fileName.replace(/\\/g, '/');
+						err.message = fileName + detail;
+					}
+
 					errors.push(err);
 				},
 				finish: function(info) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -302,6 +302,7 @@ module compile {
 				console.warn('You cannot combine option `isolatedModules` with `out`, `outFile` or `sortOutput`');
 			}
 
+			project.options['newLine'] = (<any>ts).NewLineKind.LineFeed; //new line option/kind fails TS1.4 typecheck
 			project.options.sourceMap = false;
 			project.options.declaration = false;
 			project.options['inlineSourceMap'] = true;


### PR DESCRIPTION
LF/CRLF was wreaking havoc. Use gulp-eol to force all output to LF, and fix path separators in error output as needed.