### PR TITLE
Include typing information in compiled release

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ var gulp = require('gulp');
 var rimraf = require('rimraf');
 var fs = require('fs');
 var path = require('path');
+var mergeStream = require('merge-stream');
 var ts = require('./release/main');
 
 var plumber = require('gulp-plumber');
@@ -25,6 +26,7 @@ function findTSDefinition(location) {
 var tsOptions = {
 	target: 'es5',
 	module: 'commonjs',
+	declaration: true,
 	preserveConstEnums: true,
 	typescript: require('typescript')
 };
@@ -57,7 +59,7 @@ gulp.task('scripts', ['clean'], function() {
 	var tsResult = gulp.src(paths.scripts.concat(paths.definitionTypeScript))
 		.pipe(ts(tsProject));
 
-	return tsResult.js
+	return mergeStream(tsResult.js, tsResult.dts)
 		.pipe(gulp.dest(paths.releaseBeta));
 });
 
@@ -159,7 +161,7 @@ gulp.task('test-run', ['clean-test', 'scripts'], function(cb) {
 		cb();
 		return;
 	}
-	
+
 	var isFailed = false;
 	for (var i = 0; i < tests.length; i++) {
 		runTest(tests[i], function(failed) {

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as ts from 'typescript';
 import * as tsApi from './tsapi';
 import * as gutil from 'gulp-util';
@@ -79,7 +77,7 @@ export class Host implements ts.CompilerHost {
 	writeFile = (fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) => {
 		this.output[fileName] = data;
 	}
-	
+
 	fileExists(fileName: string) {
 		if (fileName === '__lib.d.ts') {
 			return true;
@@ -87,25 +85,25 @@ export class Host implements ts.CompilerHost {
 
 		let sourceFile = this.input.getFile(fileName);
 		if (sourceFile) return true;
-		
+
 		if (this.externalResolve) {
 			try {
 				const stat = fs.statSync(fileName);
 				if (!stat) return false;
 				return stat.isFile();
 			} catch (ex) {
-				
+
 			}
 		}
 		return false;
 	}
-	
+
 	readFile(fileName: string) {
 		const normalizedFileName = utils.normalizePath(fileName);
-		
+
 		let sourceFile = this.input.getFile(fileName);
 		if (sourceFile) return sourceFile.content;
-		
+
 		if (this.externalResolve) {
 			// Read the whole file (and cache contents) to prevent race conditions.
 			let text: string;

--- a/lib/input.ts
+++ b/lib/input.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as ts from 'typescript';
 import * as gutil from 'gulp-util';
 import * as path from 'path';
@@ -112,12 +110,12 @@ export class FileDictionary {
 		}
 		return fileNames;
 	}
-	
+
 	private getSourceFileNames(onlyGulp?: boolean) {
 		const fileNames = this.getFileNames(onlyGulp);
 		const sourceFileNames = fileNames
 			.filter(fileName => fileName.substr(fileName.length - 5).toLowerCase() !== '.d.ts');
-		
+
 		if (sourceFileNames.length === 0) {
 			// Only definition files, so we will calculate the common base path based on the
 			// paths of the definition files.
@@ -125,7 +123,7 @@ export class FileDictionary {
 		}
 		return sourceFileNames;
 	}
-	
+
 	get commonBasePath() {
 		const fileNames = this.getSourceFileNames(true);
 		return utils.getCommonBasePathOfArray(

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -240,10 +240,10 @@ module compile {
 		removeComments?: boolean;
 		suppressImplicitAnyIndexErrors?: boolean;
 
-		target: string | ts.ScriptTarget;
-		module: string | ts.ModuleKind;
-		moduleResolution: string | number;
-		jsx: string | number;
+		target?: string | ts.ScriptTarget;
+		module?: string | ts.ModuleKind;
+		moduleResolution?: string | number;
+		jsx?: string | number;
 
 		declarationFiles?: boolean;
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as ts from 'typescript';
 import * as fs from 'fs';
 import * as gutil from 'gulp-util';
@@ -85,7 +83,7 @@ function compile(param?: any, filters?: compile.FilterSettings, theReporter?: _r
 	if (param instanceof project.Project) {
 		proj = param;
 		if (proj.running) {
-			throw new Error('gulp-typescript: A project cannot be used in two compilations at the same time. Create multiple projects with createProject instead.'); 
+			throw new Error('gulp-typescript: A project cannot be used in two compilations at the same time. Create multiple projects with createProject instead.');
 		}
 		proj.running = true;
 	} else {

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as stream from 'stream';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -88,14 +86,14 @@ export class Output {
 					file.skipPush = true;
 					return;
 				}
-				
+
 				if (this.project.singleOutput) {
 					file.original = this.project.input.firstSourceFile;
 					file.sourceMapOrigins = this.project.input.getFileNames(true).map(fName => this.project.input.getFile(fName));
 				} else {
 					const originalFileName = path.resolve(file.sourceMap.sourceRoot, file.sourceMap.sources[0]);
 					file.original = this.project.input.getFile(originalFileName);
-					
+
 					if (!file.original) {
 						console.error(`Could not find input file ${ originalFileName }. This is probably an issue of gulp-typescript.`
 							+ `\nPlease report it at https://github.com/ivogabe/gulp-typescript/issues`
@@ -153,10 +151,10 @@ export class Output {
 		const generator = sourceMap.SourceMapGenerator.fromSourceMap(new sourceMap.SourceMapConsumer(map));
 		for (const sourceFile of file.sourceMapOrigins) {
 			if (!sourceFile || !sourceFile.gulp || !sourceFile.gulp.sourceMap) continue;
-			
+
 			const inputOriginalMap = sourceFile.gulp.sourceMap;
 			const inputMap: sourceMap.RawSourceMap = typeof inputOriginalMap === 'object' ? inputOriginalMap : JSON.parse(inputOriginalMap);
-			
+
 			/* We should only apply the input mappings if the input mapping isn't empty,
 			 * since `generator.applySourceMap` has a really bad performance on big inputs.
 			 */
@@ -164,7 +162,7 @@ export class Output {
 				const consumer = new sourceMap.SourceMapConsumer(inputMap);
 				generator.applySourceMap(consumer);
 			}
-			
+
 			if (!inputMap.sources || !inputMap.sourcesContent) continue;
 			for (const i in inputMap.sources) {
 				generator.setSourceContent(inputMap.sources[i], inputMap.sourcesContent[i]);
@@ -220,7 +218,7 @@ export class Output {
 
 				if (file.original && file.original.ts) {
 					let references = file.original.ts.referencedFiles.map(file => tsApi.getFileName(file));
-	
+
 					for (const reference of references) {
 						sortedEmit(utils.splitExtension(reference)[0]);
 					}
@@ -232,7 +230,7 @@ export class Output {
 				sortedEmit(fileName);
 			}
 		}
-		
+
 		this.results = results;
 		if (this.project.reporter.finish) this.project.reporter.finish(results);
 
@@ -247,7 +245,7 @@ export class Output {
 		const err = <reporter.TypeScriptError> new Error();
 		err.name = 'TypeScript error';
 		err.diagnostic = info;
-		
+
 		const codeAndMessageText = ts.DiagnosticCategory[info.category].toLowerCase() +
 			' TS' +
 			info.code +
@@ -301,7 +299,7 @@ export class Output {
 	}
 	error(error: reporter.TypeScriptError) {
 		if (!error) return;
-		
+
 		// Save errors for lazy compilation (if the next input is the same as the current),
 		this.errors.push(error);
 		// call reporter callback

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as stream from 'stream';
 import * as ts from 'typescript';
 import * as vfs from 'vinyl-fs';
@@ -20,10 +18,10 @@ export class Project {
 	output: Output;
 	previousOutput: Output;
 	compiler: ICompiler;
-	
+
 	configFileName: string;
 	config: TsConfig;
-	
+
 	running = false;
 
 	// region settings
@@ -87,17 +85,17 @@ export class Project {
 		this.previousOutput = this.output;
 		this.output = new Output(this, outputJs, outputDts);
 	}
-	
+
 	src() {
 		let configPath = path.dirname(this.configFileName)
 		let base: string;
 		if (this.config.compilerOptions && this.config.compilerOptions.rootDir) {
 			base = path.resolve(configPath, this.config.compilerOptions.rootDir);
 		}
-		
+
 		if (!this.config.files) {
 			let files = [path.join(configPath, '**/*.ts')];
-			
+
 			if (tsApi.isTS16OrNewer(this.typescript)) {
 				files.push(path.join(configPath, '**/*.tsx'));
 			}
@@ -138,7 +136,7 @@ export class Project {
 		}
 		const files = this.config.files.map(file => path.resolve(configPath, file));
 		if (base === undefined) base = utils.getCommonBasePathOfArray(files.map(file => path.dirname(file)));
-		
+
 		const resolvedFiles: string[] = [];
 		const checkMissingFiles = through2.obj(function (file: gutil.File, enc, callback) {
 			this.push(file);
@@ -159,7 +157,7 @@ export class Project {
 				}
 			}
 		});
-		
+
 		const vinylOptions = { base, allowEmpty: true };
 		return vfs.src(this.config.files.map(file => path.resolve(configPath, file)), vinylOptions)
 			.pipe(checkMissingFiles);

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as ts from 'typescript';
 import * as tsApi from './tsapi';
 import * as gutil from 'gulp-util';
@@ -32,7 +30,7 @@ export interface CompilationResult {
 	globalErrors: number;
 	semanticErrors: number;
 	emitErrors: number;
-	
+
 	emitSkipped: boolean;
 }
 export function emptyCompilationResult(): CompilationResult {
@@ -55,17 +53,17 @@ function defaultFinishHandler(results: CompilationResult) {
 	let hasError = false;
 	const showErrorCount = (count: number, type: string) => {
 		if (count === 0) return;
-		
+
 		gutil.log('TypeScript:', gutil.colors.magenta(count.toString()), (type !== '' ? type + ' ' : '') + (count === 1 ? 'error' : 'errors'));
 		hasError = true;
 	};
-	
+
 	showErrorCount(results.transpileErrors, '');
 	showErrorCount(results.syntaxErrors, 'syntax');
 	showErrorCount(results.globalErrors, 'global');
 	showErrorCount(results.semanticErrors, 'semantic');
 	showErrorCount(results.emitErrors, 'emit');
-	
+
 	if (results.emitSkipped) {
 		gutil.log('TypeScript: emit', gutil.colors.red('failed'));
 	} else if (hasError) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
-
 import * as path from 'path';
 
 export interface Map<T> {
@@ -40,10 +38,10 @@ export function getCommonBasePath(a: string, b: string) {
 	let commonLength = 0;
 	for (let i = 0; i < aSplit.length && i < bSplit.length; i++) {
 		if (aSplit[i] !== bSplit[i]) break;
-		
+
 		commonLength += aSplit[i].length + 1;
 	}
-	
+
 	return a.substr(0, commonLength);
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     }
   ],
   "main": "release/main.js",
+  "typings": "release/main.d.ts",
   "dependencies": {
     "gulp-util": "~3.0.7",
     "source-map": "~0.5.3",
@@ -63,12 +64,13 @@
   },
   "devDependencies": {
     "gulp": "~3.9.0",
-    "rimraf": "~2.4.4",
-    "gulp-sourcemaps": "~1.6.0",
     "gulp-concat": "~2.6.0",
-    "gulp-header": "~1.7.1",
     "gulp-diff": "~1.0.0",
-    "gulp-plumber": "~1.0.1"
+    "gulp-header": "~1.7.1",
+    "gulp-plumber": "~1.0.1",
+    "gulp-sourcemaps": "~1.6.0",
+    "merge-stream": "^1.0.0",
+    "rimraf": "~2.4.4"
   },
   "scripts": {
     "test": "gulp"

--- a/release/compiler.d.ts
+++ b/release/compiler.d.ts
@@ -1,0 +1,47 @@
+import * as ts from 'typescript';
+import { RawSourceMap } from 'source-map';
+import { File } from './input';
+import { Host } from './host';
+import { Project } from './project';
+export interface ICompiler {
+    prepare(_project: Project): void;
+    inputFile(file: File): any;
+    inputDone(): any;
+    /**
+     * Corrects the paths in the sourcemap.
+     * Returns true when the file is located
+     * under the base path.
+     */
+    correctSourceMap(map: RawSourceMap): boolean;
+}
+/**
+ * Compiles a whole project, with full type checking
+ */
+export declare class ProjectCompiler implements ICompiler {
+    host: Host;
+    project: Project;
+    program: ts.Program;
+    prepare(_project: Project): void;
+    inputFile(file: File): void;
+    inputDone(): void;
+    private _commonBaseDiff;
+    /**
+     * Calculates the difference between the common base directory calculated based on the base paths of the input files
+     * and the common source directory calculated by TypeScript.
+     */
+    private commonBaseDiff;
+    correctSourceMap(map: RawSourceMap): boolean;
+    private removeSourceMapComment(content);
+}
+export declare class FileCompiler implements ICompiler {
+    host: Host;
+    project: Project;
+    program: ts.Program;
+    private errorsPerFile;
+    private previousErrorsPerFile;
+    private compilationResult;
+    prepare(_project: Project): void;
+    inputFile(file: File): void;
+    inputDone(): void;
+    correctSourceMap(map: RawSourceMap): boolean;
+}

--- a/release/filter.d.ts
+++ b/release/filter.d.ts
@@ -1,0 +1,12 @@
+import { Project } from './project';
+import * as main from './main';
+export declare class Filter {
+    project: Project;
+    constructor(project: Project, filters: main.FilterSettings);
+    private mapFilenamesToFiles(filenames);
+    private getFile(searchFileName);
+    private referencedFrom;
+    private referencedFromAll;
+    match(fileName: string): boolean;
+    private matchReferencedFrom(filename, file);
+}

--- a/release/host.d.ts
+++ b/release/host.d.ts
@@ -1,0 +1,25 @@
+import * as ts from 'typescript';
+import { FileCache } from './input';
+import * as utils from './utils';
+export declare class Host implements ts.CompilerHost {
+    static libDefault: utils.Map<ts.SourceFile>;
+    static getLibDefault(typescript: typeof ts, libFileName: string): any;
+    typescript: typeof ts;
+    currentDirectory: string;
+    private externalResolve;
+    private libFileName;
+    input: FileCache;
+    output: utils.Map<string>;
+    constructor(typescript: typeof ts, currentDirectory: string, input: FileCache, externalResolve: boolean, libFileName: string);
+    private reset();
+    getNewLine(): string;
+    useCaseSensitiveFileNames(): boolean;
+    getCurrentDirectory: () => string;
+    getCanonicalFileName(filename: string): string;
+    getDefaultLibFilename(): string;
+    getDefaultLibFileName(): string;
+    writeFile: (fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) => void;
+    fileExists(fileName: string): boolean;
+    readFile(fileName: string): string;
+    getSourceFile: (fileName: string, languageVersion: ts.ScriptTarget, onError?: (message: string) => void) => ts.SourceFile;
+}

--- a/release/host.js
+++ b/release/host.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var tsApi = require('./tsapi');
 var utils = require('./utils');

--- a/release/input.d.ts
+++ b/release/input.d.ts
@@ -1,0 +1,69 @@
+import * as ts from 'typescript';
+import * as utils from './utils';
+import { VinylFile } from './vinyl-file';
+export declare enum FileChangeState {
+    New = 0,
+    Equal = 1,
+    Modified = 2,
+    Deleted = 3,
+    NotFound = 4,
+}
+export declare enum FileKind {
+    Source = 0,
+    Config = 1,
+}
+export interface FileChange {
+    previous: File;
+    current: File;
+    state: FileChangeState;
+}
+export interface File {
+    gulp?: VinylFile;
+    fileNameNormalized: string;
+    fileNameOriginal: string;
+    content: string;
+    kind: FileKind;
+    ts?: ts.SourceFile;
+}
+export declare module File {
+    function fromContent(fileName: string, content: string): File;
+    function fromGulp(file: VinylFile): File;
+    function equal(a: File, b: File): boolean;
+    function getChangeState(previous: File, current: File): FileChangeState;
+}
+export declare class FileDictionary {
+    files: utils.Map<File>;
+    firstSourceFile: File;
+    typescript: typeof ts;
+    constructor(typescript: typeof ts);
+    addGulp(gFile: VinylFile): File;
+    addContent(fileName: string, content: string): File;
+    private addFile(file);
+    getFile(name: string): File;
+    initTypeScriptSourceFile: (file: File) => void;
+    getFileNames(onlyGulp?: boolean): string[];
+    private getSourceFileNames(onlyGulp?);
+    commonBasePath: string;
+    commonSourceDirectory: string;
+}
+export declare class FileCache {
+    previous: FileDictionary;
+    current: FileDictionary;
+    options: ts.CompilerOptions;
+    noParse: boolean;
+    typescript: typeof ts;
+    version: number;
+    constructor(typescript: typeof ts, options: ts.CompilerOptions);
+    addGulp(gFile: VinylFile): File;
+    addContent(fileName: string, content: string): File;
+    reset(): void;
+    private createDictionary();
+    private initTypeScriptSourceFile(file);
+    getFile(name: string): File;
+    getFileChange(name: string): FileChange;
+    getFileNames(onlyGulp?: boolean): string[];
+    firstSourceFile: File;
+    commonBasePath: string;
+    commonSourceDirectory: string;
+    isChanged(onlyGulp?: boolean): boolean;
+}

--- a/release/input.js
+++ b/release/input.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var path = require('path');
 var tsApi = require('./tsapi');

--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -1,0 +1,47 @@
+import * as ts from 'typescript';
+import * as project from './project';
+import * as _reporter from './reporter';
+declare function compile(): any;
+declare function compile(proj: project.Project, filters?: compile.FilterSettings, theReporter?: _reporter.Reporter): any;
+declare function compile(settings: compile.Settings, filters?: compile.FilterSettings, theReporter?: _reporter.Reporter): any;
+declare module compile {
+    interface Settings {
+        out?: string;
+        outFile?: string;
+        outDir?: string;
+        allowNonTsExtensions?: boolean;
+        charset?: string;
+        codepage?: number;
+        declaration?: boolean;
+        locale?: string;
+        mapRoot?: string;
+        noEmitOnError?: boolean;
+        noImplicitAny?: boolean;
+        noLib?: boolean;
+        noLibCheck?: boolean;
+        noResolve?: boolean;
+        preserveConstEnums?: boolean;
+        removeComments?: boolean;
+        suppressImplicitAnyIndexErrors?: boolean;
+        target: string | ts.ScriptTarget;
+        module: string | ts.ModuleKind;
+        moduleResolution: string | number;
+        jsx: string | number;
+        declarationFiles?: boolean;
+        noExternalResolve?: boolean;
+        sortOutput?: boolean;
+        typescript?: typeof ts;
+        isolatedModules?: boolean;
+        rootDir?: string;
+        sourceRoot?: string;
+    }
+    interface FilterSettings {
+        referencedFrom: string[];
+    }
+    export import Project = project.Project;
+    export import reporter = _reporter;
+    function createProject(settings?: Settings): any;
+    function createProject(tsConfigFileName: string, settings?: Settings): any;
+    function filter(project: Project, filters: FilterSettings): NodeJS.ReadWriteStream;
+}
+export = compile;

--- a/release/main.d.ts
+++ b/release/main.d.ts
@@ -23,10 +23,10 @@ declare module compile {
         preserveConstEnums?: boolean;
         removeComments?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;
-        target: string | ts.ScriptTarget;
-        module: string | ts.ModuleKind;
-        moduleResolution: string | number;
-        jsx: string | number;
+        target?: string | ts.ScriptTarget;
+        module?: string | ts.ModuleKind;
+        moduleResolution?: string | number;
+        jsx?: string | number;
         declarationFiles?: boolean;
         noExternalResolve?: boolean;
         sortOutput?: boolean;

--- a/release/main.js
+++ b/release/main.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/release/output.d.ts
+++ b/release/output.d.ts
@@ -1,0 +1,52 @@
+import * as stream from 'stream';
+import * as ts from 'typescript';
+import * as sourceMap from 'source-map';
+import * as utils from './utils';
+import * as input from './input';
+import * as reporter from './reporter';
+import * as project from './project';
+export interface OutputFile {
+    fileName: string;
+    original: input.File;
+    sourceMapOrigins: input.File[];
+    extension: {
+        [kind: number]: string;
+    };
+    content: {
+        [kind: number]: string;
+    };
+    pushed: boolean;
+    skipPush: boolean;
+    sourceMapsApplied: boolean;
+    sourceMap: sourceMap.RawSourceMap;
+    sourceMapString: string;
+}
+export declare enum OutputFileKind {
+    JavaScript = 0,
+    SourceMap = 1,
+    Definitions = 2,
+}
+export declare class Output {
+    static knownExtensions: string[];
+    constructor(_project: project.Project, streamJs: stream.Readable, streamDts: stream.Readable);
+    project: project.Project;
+    files: utils.Map<OutputFile>;
+    errors: reporter.TypeScriptError[];
+    results: reporter.CompilationResult;
+    streamJs: stream.Readable;
+    streamDts: stream.Readable;
+    write(fileName: string, content: string): void;
+    /**
+     * Adds the file to the `this.files`.
+     * If there is already a file with the specified `fileName`, it will be merged.
+     * This method should be called 3 times, 1 time for each `OutputFileKind`.
+     * @param fileName The extensionless filename.
+     */
+    private addOrMergeFile(fileName, extension, kind, content);
+    private applySourceMaps(file);
+    private emit(file);
+    finish(results: reporter.CompilationResult): void;
+    private getError(info);
+    diagnostic(info: ts.Diagnostic): void;
+    error(error: reporter.TypeScriptError): void;
+}

--- a/release/output.js
+++ b/release/output.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var path = require('path');
 var ts = require('typescript');

--- a/release/project.d.ts
+++ b/release/project.d.ts
@@ -1,0 +1,51 @@
+import * as stream from 'stream';
+import * as ts from 'typescript';
+import { FilterSettings } from './main';
+import { Reporter } from './reporter';
+import { FileCache } from './input';
+import { Output } from './output';
+import { ICompiler } from './compiler';
+import { TsConfig } from './tsconfig';
+export declare class Project {
+    input: FileCache;
+    output: Output;
+    previousOutput: Output;
+    compiler: ICompiler;
+    configFileName: string;
+    config: TsConfig;
+    running: boolean;
+    /**
+     * The TypeScript library that is used for this project.
+     * Can also be jsx-typescript for example.
+     */
+    typescript: typeof ts;
+    options: ts.CompilerOptions;
+    /**
+     * Whether there should not be loaded external files to the project.
+     * Example:
+     *   In the lib directory you have .ts files.
+     *   In the definitions directory you have the .d.ts files.
+     *   If you turn this option on, you should add in your gulp file the definitions directory as an input source.
+     * Advantage:
+     * - Faster builds
+     * Disadvantage:
+     * - If you forget some directory, your compile will fail.
+     */
+    noExternalResolve: boolean;
+    /**
+     * Sort output based on <reference> tags.
+     * tsc does this when you pass the --out parameter.
+     */
+    sortOutput: boolean;
+    filterSettings: FilterSettings;
+    singleOutput: boolean;
+    reporter: Reporter;
+    currentDirectory: string;
+    constructor(configFileName: string, config: TsConfig, options: ts.CompilerOptions, noExternalResolve: boolean, sortOutput: boolean, typescript?: typeof ts);
+    /**
+     * Resets the compiler.
+     * The compiler needs to be reset for incremental builds.
+     */
+    reset(outputJs: stream.Readable, outputDts: stream.Readable): void;
+    src(): NodeJS.ReadWriteStream;
+}

--- a/release/project.js
+++ b/release/project.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var stream = require('stream');
 var ts = require('typescript');

--- a/release/reporter.d.ts
+++ b/release/reporter.d.ts
@@ -1,0 +1,39 @@
+import * as ts from 'typescript';
+import * as gutil from 'gulp-util';
+export interface TypeScriptError extends Error {
+    fullFilename?: string;
+    relativeFilename?: string;
+    file?: gutil.File;
+    tsFile?: ts.SourceFile;
+    diagnostic: ts.Diagnostic;
+    startPosition?: {
+        position: number;
+        line: number;
+        character: number;
+    };
+    endPosition?: {
+        position: number;
+        line: number;
+        character: number;
+    };
+}
+export interface CompilationResult {
+    /**
+     * Only used when using isolatedModules.
+     */
+    transpileErrors: number;
+    syntaxErrors: number;
+    globalErrors: number;
+    semanticErrors: number;
+    emitErrors: number;
+    emitSkipped: boolean;
+}
+export declare function emptyCompilationResult(): CompilationResult;
+export interface Reporter {
+    error?: (error: TypeScriptError, typescript: typeof ts) => void;
+    finish?: (results: CompilationResult) => void;
+}
+export declare function nullReporter(): Reporter;
+export declare function defaultReporter(): Reporter;
+export declare function longReporter(): Reporter;
+export declare function fullReporter(fullFilename?: boolean): Reporter;

--- a/release/reporter.js
+++ b/release/reporter.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var gutil = require('gulp-util');
 function emptyCompilationResult() {

--- a/release/tsapi.d.ts
+++ b/release/tsapi.d.ts
@@ -1,0 +1,73 @@
+import * as ts from 'typescript';
+import { CompilationResult } from './reporter';
+export interface TypeScript14 {
+    createSourceFile(filename: string, content: string, target: ts.ScriptTarget, version: string): any;
+}
+export interface TypeScript15 {
+    createSourceFile(fileName: string, content: string, target: ts.ScriptTarget, isOpen: boolean): any;
+    findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean): string;
+    flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain15, newLine: string): string;
+    transpile(input: string, compilerOptions?: ts.CompilerOptions, fileName?: string, diagnostics?: ts.Diagnostic[]): string;
+}
+export interface TypeScript17 {
+    parseConfigFileTextToJson(fileName: string, jsonText: string): {
+        config?: any;
+        error?: ts.Diagnostic;
+    };
+}
+export declare function parseTsConfig(typescript: TypeScript14 | TypeScript15 | TypeScript17, fileName: string, content: string): {
+    config?: any;
+    error?: ts.Diagnostic;
+};
+export declare type CreateProgram = (rootNames: string[], options: ts.CompilerOptions, host?: ts.CompilerHost, oldProgram?: ts.Program) => ts.Program;
+export interface Program14 {
+    getDiagnostics(): ts.Diagnostic[];
+    getTypeChecker(fullTypeCheckMode: boolean): TypeChecker14;
+}
+export interface Program15 {
+    getSyntacticDiagnostics(): ts.Diagnostic[];
+    getGlobalDiagnostics(): ts.Diagnostic[];
+    getSemanticDiagnostics(): ts.Diagnostic[];
+    getDeclarationDiagnostics(): ts.Diagnostic[];
+    emit(): {
+        diagnostics: ts.Diagnostic[];
+        emitSkipped: boolean;
+    };
+}
+export interface TypeChecker14 {
+    getDiagnostics(sourceFile?: ts.SourceFile): ts.Diagnostic[];
+    emitFiles(): {
+        diagnostics: ts.Diagnostic[];
+    };
+}
+export interface DiagnosticMessageChain15 {
+    messageText: string;
+    category: ts.DiagnosticCategory;
+    code: number;
+    next?: DiagnosticMessageChain15;
+}
+export interface TSFile14 {
+    getLineAndCharacterFromPosition(pos: number): ts.LineAndCharacter;
+}
+export interface TSFile15 {
+    getLineAndCharacterOfPosition(pos: number): ts.LineAndCharacter;
+}
+export interface TSOptions18 extends ts.CompilerOptions {
+    allowJs: boolean;
+    suppressOutputPathCheck: boolean;
+}
+export declare function isTS14(typescript: typeof ts): boolean;
+export declare function isTS16OrNewer(typescript: typeof ts): boolean;
+export declare function getFileName(thing: {
+    filename: string;
+} | {
+    fileName: string;
+}): string;
+export declare function getDiagnosticsAndEmit(program: Program14 | Program15): [ts.Diagnostic[], CompilationResult];
+export declare function getLineAndCharacterOfPosition(typescript: typeof ts, file: TSFile14 | TSFile15, position: number): {
+    line: number;
+    character: number;
+};
+export declare function createSourceFile(typescript: TypeScript14 | TypeScript15, fileName: string, content: string, target: ts.ScriptTarget, version?: string): any;
+export declare function flattenDiagnosticMessageText(typescript: TypeScript14 | TypeScript15, messageText: string | DiagnosticMessageChain15): string;
+export declare function transpile(typescript: TypeScript14 | TypeScript15, input: string, compilerOptions?: ts.CompilerOptions, fileName?: string, diagnostics?: ts.Diagnostic[]): string;

--- a/release/tsconfig.d.ts
+++ b/release/tsconfig.d.ts
@@ -1,0 +1,5 @@
+export interface TsConfig {
+    files?: string[];
+    exclude?: string[];
+    compilerOptions?: any;
+}

--- a/release/utils.d.ts
+++ b/release/utils.d.ts
@@ -1,0 +1,16 @@
+export interface Map<T> {
+    [key: string]: T;
+}
+export declare function normalizePath(pathString: string): string;
+/**
+ * Splits a filename into an extensionless filename and an extension.
+ * 'bar/foo.js' is turned into ['bar/foo', 'js']
+ * 'foo.d.ts' is parsed as ['foo', 'd.ts'] if you add 'd.ts' to knownExtensions.
+ * @param knownExtensions An array with known extensions, that contain multiple parts, like 'd.ts'. 'a.b.c' should be listed before 'b.c'.
+ */
+export declare function splitExtension(fileName: string, knownExtensions?: string[]): [string, string];
+/**
+ * Finds the common base path of two directories
+ */
+export declare function getCommonBasePath(a: string, b: string): string;
+export declare function getCommonBasePathOfArray(paths: string[]): string;

--- a/release/utils.js
+++ b/release/utils.js
@@ -1,4 +1,3 @@
-///<reference path='../typings/tsd.d.ts'/>
 "use strict";
 var path = require('path');
 function normalizePath(pathString) {

--- a/release/vinyl-file.d.ts
+++ b/release/vinyl-file.d.ts
@@ -1,5 +1,4 @@
 import Vinyl = require('vinyl');
-
 export interface VinylFile extends Vinyl {
-	sourceMap?: any;
+    sourceMap?: any;
 }

--- a/release/vinyl-file.js
+++ b/release/vinyl-file.js
@@ -1,2 +1,1 @@
-/// <reference path="../typings/tsd.d.ts" />
 "use strict";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,11 @@
 {
 	"files": [
-		"lib/compiler.ts",
-		"lib/filter.ts",
-		"lib/host.ts",
-		"lib/input.ts",
 		"lib/main.ts",
-		"lib/output.ts",
-		"lib/project.ts",
-		"lib/reporter.ts",
-		"lib/tsapi.ts",
-		"lib/utils.ts",
-		"lib/vinyl-file.ts",
-		"typings/tsd.d.ts",
-		"typings/chalk/chalk.d.ts",
-		"typings/gulp-util/gulp-util.d.ts",
-		"typings/node/node.d.ts",
-		"typings/source-map/source-map.d.ts",
-		"typings/through2/through2.d.ts",
-		"typings/vinyl/vinyl.d.ts",
-		"typings/vinyl-fs/vinyl-fs.d.ts"
+		"typings/tsd.d.ts"
 	],
 	"compilerOptions": {
 		"target": "ES5",
+    "moduleResolution": "node",
 		"module": "commonjs"
 	}
 }


### PR DESCRIPTION
This PR bundles `.d.ts` information with the compiled JS and sets the `typings` property in `package.json` so dependent packages can use gulp-typescript typings in their `gulpfile.ts`*. In order to emit correct `.d.ts` files, `/// <reference/>`s to `tsd.d.ts` were removed. In fact, they are unnecessary when specifying the `tsd.d.ts` in the `tsconfig.json`, so it just cleans things up a bit. Additionally, all non-entry files were removed from `tsconfig.json` as Typescript will pick them up when you `import` them.

\* If you name your gulpfile `gulpfile.ts` and `npm install ts-node`, gulp will run your Typescript!