### PR TITLE
Use correct 'rootDir' setting in Project.src

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -91,8 +91,8 @@ export class Project {
 	src() {
 		let configPath = path.dirname(this.configFileName)
 		let base: string;
-		if (this.options.rootDir) {
-			base = path.resolve(configPath, this.options.rootDir);
+		if (this.options["rootDir"]) {
+			base = path.resolve(configPath, this.options["rootDir"]);
 		}
 
 		if (!this.config.files) {

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -91,8 +91,8 @@ export class Project {
 	src() {
 		let configPath = path.dirname(this.configFileName)
 		let base: string;
-		if (this.config.compilerOptions && this.config.compilerOptions.rootDir) {
-			base = path.resolve(configPath, this.config.compilerOptions.rootDir);
+		if (this.options.rootDir) {
+			base = path.resolve(configPath, this.options.rootDir);
 		}
 
 		if (!this.config.files) {


### PR DESCRIPTION
This fixes an issue in which a `rootDir` specified in the gulp task was not being used to determine the value for `base` (`base` was always `undefined`).

`this.config.compilerOptions` only contains the options defined in the `tsconfig.json` file. Overrides defined when creating the `TsProject` instance must be accessed via `this.options`.