### PR TITLE
Virtual filename for sourcemap should match virtual filename for output file + test

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -105,11 +105,6 @@ export class Output {
 						file.skipPush = !file.original.gulp;
 						file.sourceMapOrigins = [file.original];
 					}
-					const [, jsExtension] = utils.splitExtension(file.sourceMap.file); // js or jsx
-					// Fix the output filename in the source map, which must be relative
-					// to the source root or it won't work correctly in gulp-sourcemaps if
-					// there are more transformations down in the pipeline.
-					file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, originalFileName).replace(/\.ts$/, '.' + jsExtension);
 				}
 
 				this.applySourceMaps(file);
@@ -205,6 +200,7 @@ export class Output {
 			base
 		});
 		if (file.original.gulp.sourceMap) fileJs.sourceMap = JSON.parse(file.sourceMapString);
+
 		this.streamJs.push(fileJs);
 
 		if (this.project.options.declaration) {
@@ -252,7 +248,7 @@ export class Output {
 	private getError(info: ts.Diagnostic): reporter.TypeScriptError {
 		let fileName = info.file && tsApi.getFileName(info.file);
 		const file = fileName && this.project.input.getFile(fileName);
-		
+
 		return utils.getError(info, this.project.typescript, file);
 	}
 	diagnostic(info: ts.Diagnostic) {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     {
       "name": "Yui Tanglertsampan",
       "email": "yuisu@microsoft.com"
+    },
+    {
+      "name": "John Vilk",
+      "email": "jvilk@cs.umass.edu"
     }
   ],
   "main": "release/main.js",
@@ -63,12 +67,15 @@
     "vinyl-fs": "~2.4.3"
   },
   "devDependencies": {
+    "babel-preset-react": "6.5.0",
     "gulp": "~3.9.1",
+    "gulp-babel": "6.1.2",
     "gulp-concat": "~2.6.0",
     "gulp-diff": "~1.0.0",
     "gulp-header": "~1.7.1",
     "gulp-plumber": "~1.1.0",
     "gulp-sourcemaps": "~1.6.0",
+    "gulp-uglify": "1.5.3",
     "merge-stream": "~1.0.0",
     "rimraf": "~2.5.2"
   },

--- a/test/baselines/sourceMapPipeline/1.4/errors.txt
+++ b/test/baselines/sourceMapPipeline/1.4/errors.txt
@@ -1,0 +1,9 @@
+TypeScript error: error TS6054: File '/Users/jvilk/Code/gulp-typescript/test/sourceMapPipeline/Main/Foo.tsx' must have extension '.ts' or '.d.ts'.
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 1,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": true
+}

--- a/test/baselines/sourceMapPipeline/1.5/errors.txt
+++ b/test/baselines/sourceMapPipeline/1.5/errors.txt
@@ -1,0 +1,9 @@
+TypeScript error: error TS6054: File '/Users/jvilk/Code/gulp-typescript/test/sourceMapPipeline/Main/Foo.tsx' must have extension '.ts' or '.d.ts'.
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 1,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/sourceMapPipeline/1.5/js/MainFile.js
+++ b/test/baselines/sourceMapPipeline/1.5/js/MainFile.js
@@ -1,0 +1,2 @@
+var Foo=require("./Foo");console.log(Foo);
+//# sourceMappingURL=MainFile.js.map

--- a/test/baselines/sourceMapPipeline/1.5/js/MainFile.js.map
+++ b/test/baselines/sourceMapPipeline/1.5/js/MainFile.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFile.ts"],"names":["Foo","require","console","log"],"mappings":"AAAA,GAAOA,KAAGC,QAAW,QAErBC,SAAQC,IAAIH","file":"MainFile.js","sourcesContent":["import Foo = require(\"./Foo\");\n\nconsole.log(Foo);\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.6/errors.txt
+++ b/test/baselines/sourceMapPipeline/1.6/errors.txt
@@ -1,0 +1,9 @@
+
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/sourceMapPipeline/1.6/js/Foo.js
+++ b/test/baselines/sourceMapPipeline/1.6/js/Foo.js
@@ -1,0 +1,2 @@
+var Foo=React.createElement("div",null);module.exports=Foo;
+//# sourceMappingURL=Foo.js.map

--- a/test/baselines/sourceMapPipeline/1.6/js/Foo.js.map
+++ b/test/baselines/sourceMapPipeline/1.6/js/Foo.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["Foo.tsx"],"names":["Foo","React","createElement","module","exports"],"mappings":"AAAA,GAAIA,KAAOC,MAAAC,cAAA,MAAA,KACXC,QAAAC,QAASJ","file":"Foo.js","sourcesContent":["var Foo = (<div></div>);\nexport = Foo;\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.6/js/MainFile.js
+++ b/test/baselines/sourceMapPipeline/1.6/js/MainFile.js
@@ -1,0 +1,2 @@
+var Foo=require("./Foo");console.log(Foo);
+//# sourceMappingURL=MainFile.js.map

--- a/test/baselines/sourceMapPipeline/1.6/js/MainFile.js.map
+++ b/test/baselines/sourceMapPipeline/1.6/js/MainFile.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFile.ts"],"names":["Foo","require","console","log"],"mappings":"AAAA,GAAOA,KAAGC,QAAW,QAErBC,SAAQC,IAAIH","file":"MainFile.js","sourcesContent":["import Foo = require(\"./Foo\");\n\nconsole.log(Foo);\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.7/errors.txt
+++ b/test/baselines/sourceMapPipeline/1.7/errors.txt
@@ -1,0 +1,9 @@
+
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/sourceMapPipeline/1.7/js/Foo.js
+++ b/test/baselines/sourceMapPipeline/1.7/js/Foo.js
@@ -1,0 +1,2 @@
+var Foo=React.createElement("div",null);module.exports=Foo;
+//# sourceMappingURL=Foo.js.map

--- a/test/baselines/sourceMapPipeline/1.7/js/Foo.js.map
+++ b/test/baselines/sourceMapPipeline/1.7/js/Foo.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["Foo.tsx"],"names":["Foo","React","createElement","module","exports"],"mappings":"AAAA,GAAIA,KAAOC,MAAAC,cAAA,MAAA,KACXC,QAAAC,QAASJ","file":"Foo.js","sourcesContent":["var Foo = (<div></div>);\nexport = Foo;\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.7/js/MainFile.js
+++ b/test/baselines/sourceMapPipeline/1.7/js/MainFile.js
@@ -1,0 +1,2 @@
+var Foo=require("./Foo");console.log(Foo);
+//# sourceMappingURL=MainFile.js.map

--- a/test/baselines/sourceMapPipeline/1.7/js/MainFile.js.map
+++ b/test/baselines/sourceMapPipeline/1.7/js/MainFile.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFile.ts"],"names":["Foo","require","console","log"],"mappings":"AAAA,GAAOA,KAAGC,QAAW,QAErBC,SAAQC,IAAIH","file":"MainFile.js","sourcesContent":["import Foo = require(\"./Foo\");\n\nconsole.log(Foo);\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.8/errors.txt
+++ b/test/baselines/sourceMapPipeline/1.8/errors.txt
@@ -1,0 +1,9 @@
+
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/sourceMapPipeline/1.8/js/Foo.js
+++ b/test/baselines/sourceMapPipeline/1.8/js/Foo.js
@@ -1,0 +1,2 @@
+"use strict";var Foo=React.createElement("div",null);module.exports=Foo;
+//# sourceMappingURL=Foo.js.map

--- a/test/baselines/sourceMapPipeline/1.8/js/Foo.js.map
+++ b/test/baselines/sourceMapPipeline/1.8/js/Foo.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["Foo.jsx","Foo.tsx"],"names":["Foo","React","createElement","module","exports"],"mappings":"AAAA,YCAA,IAAIA,KAAOC,MAAAC,cAAA,MAAA,KACXC,QAAAC,QAASJ","file":"Foo.js","sourcesContent":["\"use strict\";\nvar Foo = (<div></div>);\nmodule.exports = Foo;\n","var Foo = (<div></div>);\nexport = Foo;\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/1.8/js/MainFile.js
+++ b/test/baselines/sourceMapPipeline/1.8/js/MainFile.js
@@ -1,0 +1,2 @@
+"use strict";var Foo=require("./Foo");console.log(Foo);
+//# sourceMappingURL=MainFile.js.map

--- a/test/baselines/sourceMapPipeline/1.8/js/MainFile.js.map
+++ b/test/baselines/sourceMapPipeline/1.8/js/MainFile.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFile.js","MainFile.ts"],"names":["Foo","require","console","log"],"mappings":"AAAA,YCAA,IAAOA,KAAGC,QAAW,QAErBC,SAAQC,IAAIH","file":"MainFile.js","sourcesContent":["\"use strict\";\nvar Foo = require(\"./Foo\");\nconsole.log(Foo);\n","import Foo = require(\"./Foo\");\n\nconsole.log(Foo);\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/dev/errors.txt
+++ b/test/baselines/sourceMapPipeline/dev/errors.txt
@@ -1,0 +1,9 @@
+
+{
+    "transpileErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/sourceMapPipeline/dev/js/Foo.js
+++ b/test/baselines/sourceMapPipeline/dev/js/Foo.js
@@ -1,0 +1,2 @@
+"use strict";var Foo=React.createElement("div",null);module.exports=Foo;
+//# sourceMappingURL=Foo.js.map

--- a/test/baselines/sourceMapPipeline/dev/js/Foo.js.map
+++ b/test/baselines/sourceMapPipeline/dev/js/Foo.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["Foo.jsx","Foo.tsx"],"names":["Foo","React","createElement","module","exports"],"mappings":"AAAA,YCAA,IAAIA,KAAOC,MAAAC,cAAA,MAAA,KACXC,QAAAC,QAASJ","file":"Foo.js","sourcesContent":["\"use strict\";\nvar Foo = (<div></div>);\nmodule.exports = Foo;\n","var Foo = (<div></div>);\nexport = Foo;\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/baselines/sourceMapPipeline/dev/js/MainFile.js
+++ b/test/baselines/sourceMapPipeline/dev/js/MainFile.js
@@ -1,0 +1,2 @@
+"use strict";var Foo=require("./Foo");console.log(Foo);
+//# sourceMappingURL=MainFile.js.map

--- a/test/baselines/sourceMapPipeline/dev/js/MainFile.js.map
+++ b/test/baselines/sourceMapPipeline/dev/js/MainFile.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFile.js","MainFile.ts"],"names":["Foo","require","console","log"],"mappings":"AAAA,YCAA,IAAOA,KAAGC,QAAW,QAErBC,SAAQC,IAAIH","file":"MainFile.js","sourcesContent":["\"use strict\";\nvar Foo = require(\"./Foo\");\nconsole.log(Foo);\n","import Foo = require(\"./Foo\");\n\nconsole.log(Foo);\n"],"sourceRoot":"../../../../sourceMapPipeline/Main/"}

--- a/test/sourceMapPipeline/Main/Foo.tsx
+++ b/test/sourceMapPipeline/Main/Foo.tsx
@@ -1,0 +1,2 @@
+var Foo = (<div></div>);
+export = Foo;

--- a/test/sourceMapPipeline/Main/MainFile.ts
+++ b/test/sourceMapPipeline/Main/MainFile.ts
@@ -1,0 +1,3 @@
+import Foo = require("./Foo");
+
+console.log(Foo);

--- a/test/sourceMapPipeline/gulptask.js
+++ b/test/sourceMapPipeline/gulptask.js
@@ -1,0 +1,28 @@
+var gulp = require('gulp');
+var sourcemaps = require('gulp-sourcemaps');
+var uglify = require('gulp-uglify');
+var babel = require('gulp-babel');
+
+// gulp-typescript => babel => uglify with end-to-end sourcemaps
+// with a source directory (Main) that TypeScript removes from virtual filenames
+module.exports = function(newTS, lib, output, reporter) {
+	var project = newTS.createProject('test/sourceMapPipeline/tsconfig.json', {
+		typescript: lib
+	});
+
+	return project.src()
+		.pipe(sourcemaps.init())
+		.pipe(newTS(project, undefined, reporter)).js
+		// No sane person would ever pipe TypeScript output through
+		// babel, but we are doing it to force a different tool to
+		// operate on our output JSX to ensure we output source maps
+		// with proper virtual paths.
+		.pipe(babel({
+			presets: ['react']
+		}))
+		.pipe(uglify())
+		// sourceRoot has /Main/ explicitly added because TypeScript lops it off,
+		// and there's no convenient way to automatically recover that.
+		.pipe(sourcemaps.write(".", { sourceRoot: '../../../../sourceMapPipeline/Main/' }))
+		.pipe(gulp.dest(output + "js"));
+}

--- a/test/sourceMapPipeline/tsconfig.json
+++ b/test/sourceMapPipeline/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "preserve"
+  },
+  "files": [
+    "Main/Foo.tsx",
+    "Main/MainFile.ts"
+  ]
+}


### PR DESCRIPTION
Funnily enough, this PR only *removes* code from `gulp-typescript` (ignoring test code).

Fixes #351.

I have added devDependencies on two frequently-used plugins to stress SourceMap support in the unit test:

- gulp-babel: To ensure our jsx sourcemaps use the appropriate extension / can be located.
  - babel-preset-react: Babel plugin for JSX
- gulp-uglify: Commonly used final step of any source map pipeline, and the plugin that originally surfaced this bug.

I have fixed the NPM versions of these dependencies so that the tests do not become flaky due to codegen changes.