### PR TITLE
Changed sourcemap file path resolution to use correct extension

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -106,10 +106,13 @@ export class Output {
 						file.sourceMapOrigins = [file.original];
 					}
 					const [, jsExtension] = utils.splitExtension(file.sourceMap.file); // js or jsx
+					const [filePath, ] = utils.splitExtension(originalFileName);
+					const outputFileName = `${filePath}.${jsExtension}`;
+
 					// Fix the output filename in the source map, which must be relative
 					// to the source root or it won't work correctly in gulp-sourcemaps if
 					// there are more transformations down in the pipeline.
-					file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, originalFileName).replace(/\.ts$/, '.' + jsExtension);
+					file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, outputFileName);
 				}
 
 				this.applySourceMaps(file);

--- a/release/output.js
+++ b/release/output.js
@@ -76,10 +76,12 @@ var Output = (function () {
                         file.sourceMapOrigins = [file.original];
                     }
                     var _a = utils.splitExtension(file.sourceMap.file), jsExtension = _a[1]; // js or jsx
+                    var filePath = utils.splitExtension(originalFileName)[0];
+                    var outputFileName = filePath + "." + jsExtension;
                     // Fix the output filename in the source map, which must be relative
                     // to the source root or it won't work correctly in gulp-sourcemaps if
                     // there are more transformations down in the pipeline.
-                    file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, originalFileName).replace(/\.ts$/, '.' + jsExtension);
+                    file.sourceMap.file = path.relative(file.sourceMap.sourceRoot, outputFileName);
                 }
                 this.applySourceMaps(file);
                 if (!this.project.sortOutput) {

--- a/test/baselines/sourceMaps/1.6/js/Main/MainFileTsx.js
+++ b/test/baselines/sourceMaps/1.6/js/Main/MainFileTsx.js
@@ -1,0 +1,6 @@
+var foo = {
+    bar: 42
+};
+console.log(foo.bar);
+
+//# sourceMappingURL=MainFileTsx.js.map

--- a/test/baselines/sourceMaps/1.6/js/Main/MainFileTsx.js.map
+++ b/test/baselines/sourceMaps/1.6/js/Main/MainFileTsx.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFileTsx.tsx"],"names":[],"mappings":"AAEA,IAAI,GAAG,GAAS;IACZ,GAAG,EAAE,EAAE;CACV,CAAC;AAEF,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC","file":"MainFileTsx.js","sourcesContent":["import IFoo = require(\"../Outer/Foo\");\n\nvar foo: IFoo = {\n    bar: 42\n};\n\nconsole.log(foo.bar);\n"],"sourceRoot":"/source/"}

--- a/test/baselines/sourceMaps/1.7/js/Main/MainFileTsx.js
+++ b/test/baselines/sourceMaps/1.7/js/Main/MainFileTsx.js
@@ -1,0 +1,6 @@
+var foo = {
+    bar: 42
+};
+console.log(foo.bar);
+
+//# sourceMappingURL=MainFileTsx.js.map

--- a/test/baselines/sourceMaps/1.7/js/Main/MainFileTsx.js.map
+++ b/test/baselines/sourceMaps/1.7/js/Main/MainFileTsx.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFileTsx.tsx"],"names":[],"mappings":"AAEA,IAAI,GAAG,GAAS;IACZ,GAAG,EAAE,EAAE;CACV,CAAC;AAEF,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC","file":"MainFileTsx.js","sourcesContent":["import IFoo = require(\"../Outer/Foo\");\n\nvar foo: IFoo = {\n    bar: 42\n};\n\nconsole.log(foo.bar);\n"],"sourceRoot":"/source/"}

--- a/test/baselines/sourceMaps/1.8/js/Main/MainFileTsx.js
+++ b/test/baselines/sourceMaps/1.8/js/Main/MainFileTsx.js
@@ -1,0 +1,7 @@
+"use strict";
+var foo = {
+    bar: 42
+};
+console.log(foo.bar);
+
+//# sourceMappingURL=MainFileTsx.js.map

--- a/test/baselines/sourceMaps/1.8/js/Main/MainFileTsx.js.map
+++ b/test/baselines/sourceMaps/1.8/js/Main/MainFileTsx.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFileTsx.tsx"],"names":[],"mappings":";AAEA,IAAI,GAAG,GAAS;IACZ,GAAG,EAAE,EAAE;CACV,CAAC;AAEF,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC","file":"MainFileTsx.js","sourcesContent":["import IFoo = require(\"../Outer/Foo\");\n\nvar foo: IFoo = {\n    bar: 42\n};\n\nconsole.log(foo.bar);\n"],"sourceRoot":"/source/"}

--- a/test/baselines/sourceMaps/dev/js/Main/MainFileTsx.js
+++ b/test/baselines/sourceMaps/dev/js/Main/MainFileTsx.js
@@ -1,0 +1,7 @@
+"use strict";
+var foo = {
+    bar: 42
+};
+console.log(foo.bar);
+
+//# sourceMappingURL=MainFileTsx.js.map

--- a/test/baselines/sourceMaps/dev/js/Main/MainFileTsx.js.map
+++ b/test/baselines/sourceMaps/dev/js/Main/MainFileTsx.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["MainFileTsx.tsx"],"names":[],"mappings":";AAEA,IAAI,GAAG,GAAS;IACZ,GAAG,EAAE,EAAE;CACV,CAAC;AAEF,OAAO,CAAC,GAAG,CAAC,GAAG,CAAC,GAAG,CAAC,CAAC","file":"MainFileTsx.js","sourcesContent":["import IFoo = require(\"../Outer/Foo\");\n\nvar foo: IFoo = {\n    bar: 42\n};\n\nconsole.log(foo.bar);\n"],"sourceRoot":"/source/"}

--- a/test/sourceMaps/Main/MainFileTsx.tsx
+++ b/test/sourceMaps/Main/MainFileTsx.tsx
@@ -1,0 +1,7 @@
+import IFoo = require("../Outer/Foo");
+
+var foo: IFoo = {
+    bar: 42
+};
+
+console.log(foo.bar);


### PR DESCRIPTION
Updated the code which modifies the sourceMap output file name to be relative to the source path so it uses the appropriate extension.

Instead of using a regex to replace the original file name's extension, it uses utils.split extension to take the first part of the original file name and the extension of the output file name, then gets the relative path using the source root.

I also added a .tsx file to the test cases and updated the baseline folder.