### PR TITLE
invalid source maps for empty mappings

### DIFF
--- a/release/output.js
+++ b/release/output.js
@@ -66,6 +66,11 @@ var Output = (function () {
                 var absolute = path.resolve(sourceFile.gulp.base, inputMap.sources[i]);
                 var relative = path.relative(output.base, absolute);
                 generator.setSourceContent(relative, inputMap.sourcesContent[i]);
+                if (inputMap.mappings === '') {
+                    if (!generator._sources.has(relative)) {
+                        generator._sources.add(relative);
+                    }
+                }
             }
         }
         return generator.toString();


### PR DESCRIPTION
When inputMap.mappings is empty string, generator.applySourceMap() is skipped which also skips adding source path into generator._sources collection. All this results with invalid source maps with empty sources and sourcesContent arrays.

Proposed fix resolves that issue.