### PR TITLE
Add `types` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     }
   ],
   "main": "release/main.js",
+  "types": "release/main.d.ts",
   "typings": "release/main.d.ts",
   "dependencies": {
     "gulp-util": "~3.0.7",


### PR DESCRIPTION
This PR adds the `types` property to package.json.

This property is used to let Typescript 2 detect the type definitions automatically so consumers do not have to configure anything to use this library. The name of the property changed from `typings` to `types` with `typescript@2`. I left the previous name for compatibility.

Reference: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html