### PR TITLE
Fix missing source maps for ts files in subdirectories on Windows

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -87,7 +87,7 @@ export class Output {
 			for (let i = 0; i < inputMap.sources.length; i++) {
 				const absolute = path.resolve(sourceFile.gulp.base, inputMap.sources[i]);
 				const relative = path.relative(output.base, absolute);
-				generator.setSourceContent(relative, inputMap.sourcesContent[i]);
+				generator.setSourceContent(utils.forwardSlashes(relative), inputMap.sourcesContent[i]);
 			}
 		}
 		return generator.toString();


### PR DESCRIPTION
Due to the fact that `gulp-sourcemaps` library always creates new SourceMap using unix style paths (tHis can be clearly seen at the line 199 of [init.js](https://github.com/floridoo/gulp-sourcemaps/blob/6972337a0953e542768b29fb43c4c41eee535859/src/init.js)):

```
    if (!sourceMap) {
      // Make an empty source map
      sourceMap = {
        version: 3,
        names: [],
        mappings: '',
        sources: [unixStylePath(file.relative)], // line 199, unix style path
        sourcesContent: [fileContent]
      };
    }
```

`gulp-typescript` should also use unix style path when using `SourceMapGenerator.setSourceContent` method directly. Otherwise source maps for `ts` files in project subdirectories on Windows system are missing due to backslash/forwardslash missmatch in the `SourceMapGenerator` ([mozzilla/source-map](https://github.com/mozilla/source-map)).