### PR TITLE
Fixes Windows issue where 'return' occured early

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,17 +125,19 @@ function runTest(name, callback) {
 			var finishInfo;
 			var reporter = {
 				error: function(err) {
-					if (path.sep === '\\') { //filenames embedded in error output contain OS-dependent path separators
-						var colon = err.message.indexOf(":");
-						if (colon === -1 || !err.diagnostic || err.message.indexOf(path.sep) === -1) {
-							return;
-						}
+					(function() {
+						if (path.sep === '\\') { //filenames embedded in error output contain OS-dependent path separators
+							var colon = err.message.indexOf(":");
+							if (colon === -1 || !err.diagnostic || err.message.indexOf(path.sep) === -1) {
+								return;
+							}
 
-						var fileName = err.message.slice(0, colon);
-						var detail = err.message.slice(colon);
-						fileName = fileName.replace(/\\/g, '/');
-						err.message = fileName + detail;
-					}
+							var fileName = err.message.slice(0, colon);
+							var detail = err.message.slice(colon);
+							fileName = fileName.replace(/\\/g, '/');
+							err.message = fileName + detail;
+						}
+					})();
 
 					errors.push(err);
 				},


### PR DESCRIPTION
When parsing messages without filenames (such as "TypeScript error: error TS2318: Cannot find global type 'Array'.") on Windows, the return statement causes execution to break out of the error function before errors.push(err) occurs. Wrapping in a function ensures that `return` does not skip over pushing onto errors array.