### PR TITLE
update readme to use outFile rather than deprecated out

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ gulp.task('default', function () {
     return gulp.src('src/**/*.ts')
         .pipe(ts({
             noImplicitAny: true,
-            out: 'output.js'
+            outFile: 'output.js'
         }))
         .pipe(gulp.dest('built/local'));
 });


### PR DESCRIPTION
Some people copy and paste code straight from github. Not me though, other people.