### PR TITLE
Update global gulp references to gulp-cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ Features
 
 How to install
 --------------
-##### 1. Install gulp
+##### 1. Install gulp CLI
 ```shell
-npm install --global gulp
+npm install --global gulp-cli
 ```
 ##### 2. Install gulp in the project dependency
 ```shell
@@ -219,7 +219,7 @@ Build gulp-typescript
 1. Clone this repo
 2. Execute `npm install`
 3. Execute `git submodule update --init` to pull down the TypeScript compiler/services versions used in the test suite.
-4. Ensure the gulp CLI is globally installed (`npm install -g gulp`).
+4. Ensure the gulp CLI is globally installed (`npm install -g gulp-cli`).
 5. Execute the tests: `gulp`.
 
 The plugin uses itself to compile. There are 2 build directories, ```release``` and ```release-2```. ```release``` must always contain a working build. ```release-2``` contains the last build. When you run ```gulp compile```, the build will be saved in the ```release-2``` directory. ```gulp test``` will compile the source to ```release-2```, and then it will run some tests. If these tests give no errors, you can run ```gulp release```. The contents from ```release-2``` will be copied to ```release```.


### PR DESCRIPTION
Users should not install gulp globally. Gulp-cli is the package for global installation, and gulp is the package for project level consumption.