### PR TITLE
Fix Project files returned with config undefined

### DIFF
--- a/lib/project.ts
+++ b/lib/project.ts
@@ -79,9 +79,9 @@ export function setupProject(projectDirectory: string, config: TsConfig, options
 	project.src = src;
 	project.typescript = typescript;
 	project.projectDirectory = projectDirectory;
-	project.config = config;
+	project.config = config || {};
 	project.options = options;
-	
+
 	const projectInfo: ProjectInfo = {
 		input,
 		singleOutput,


### PR DESCRIPTION
This fixes `Project` objects being returned with the `config` property undefined. This can happen if `createProject()` is called without a file name.