### PR TITLE
Fix @types not being resolved when using multi-project setup

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -59,7 +59,7 @@ export class ProjectCompiler implements ICompiler {
 
 		this.project.options.sourceMap = this.hasSourceMap;
 
-		const currentDirectory = utils.getCommonBasePathOfArray(
+		const currentDirectory = this.project.cwd || utils.getCommonBasePathOfArray(
 			rootFilenames.map(fileName => this.project.input.getFile(fileName).gulp.cwd)
 		);
 

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -178,7 +178,7 @@ module compile {
 			}
 		}
 
-		const project = _project.setupProject(projectDirectory, tsConfigContent, getCompilerOptions(settings, projectDirectory, tsConfigFileName), getTypeScript(settings.typescript));
+		const project = _project.setupProject(projectDirectory, tsConfigContent, getCompilerOptions(settings, projectDirectory, tsConfigFileName), getTypeScript(settings.typescript), settings.cwd);
 
 		return project;
 	}

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -177,8 +177,10 @@ module compile {
 				settings = fileNameOrSettings;
 			}
 		}
-
-		const project = _project.setupProject(projectDirectory, tsConfigContent, getCompilerOptions(settings, projectDirectory, tsConfigFileName), getTypeScript(settings.typescript), settings.cwd);
+    
+    const cwd = settings.cwd
+    delete settings.cwd
+		const project = _project.setupProject(projectDirectory, tsConfigContent, getCompilerOptions(settings, projectDirectory, tsConfigFileName), getTypeScript(settings.typescript), cwd);
 
 		return project;
 	}

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -32,6 +32,7 @@ export interface Project {
 }
 
 export interface ProjectInfo {
+  cwd: string | undefined
 	input: FileCache;
 	output: Output;
 	compiler: ICompiler;
@@ -42,7 +43,7 @@ export interface ProjectInfo {
 	reporter: Reporter;
 }
 
-export function setupProject(projectDirectory: string, config: TsConfig, options: ts.CompilerOptions, typescript: typeof ts) {
+export function setupProject(projectDirectory: string, config: TsConfig, options: ts.CompilerOptions, typescript: typeof ts, cwd: string | undefined) {
 	const input = new FileCache(typescript, options);
 	const compiler: ICompiler = options.isolatedModules ? new FileCompiler() : new ProjectCompiler();
 	let running = false;
@@ -87,6 +88,7 @@ export function setupProject(projectDirectory: string, config: TsConfig, options
 		singleOutput,
 		compiler,
 		options,
+    cwd,
 		typescript,
 		directory: projectDirectory,
 		// Set when `project` is called

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -105,7 +105,6 @@ export function longReporter(): Reporter {
 	}
 }
 export function fullReporter(fullFilename: boolean = false): Reporter {
-	const typescript: typeof ts = require('typescript');
 	return {
 		error: (error: TypeScriptError, typescript: typeof ts) => {
 			console.error('[' + gutil.colors.gray('gulp-typescript') + '] '


### PR DESCRIPTION
This is a proof-of-concept that shows how an extra `cwd` option can be passed though to the compiler so that `@types` are correctly resolved. Use it like so:

```js
const proj1 = ts.createProject('one/src/tsconfig.json', { cwd: path.resolve('one/src') })
```

I'm really not sure this is the way to go, but at least it got rid of the error messages.