### PR TITLE
Relative Path for Source Files Fixes #538

### DIFF
--- a/lib/output.ts
+++ b/lib/output.ts
@@ -95,7 +95,7 @@ export class Output {
 		function relativeToOutput(fileName: string) {
 		        const sourceDirAbsolute = path.parse(path.resolve(directory, fileName)).dir;
             		const destDirAbsolute = path.parse(output.path).dir;
-            		const fileName = path.parse(fileName).base;
+            		fileName = path.parse(fileName).base;
             		const sourcePathRelativeToDestPath = path.relative( destDirAbsolute, sourceDirAbsolute);
             		const fullRelativeSourcePath = utils.forwardSlashes(sourcePathRelativeToDestPath) + "/" +  fileName;
             		return fullRelativeSourcePath;

--- a/lib/output.ts
+++ b/lib/output.ts
@@ -93,8 +93,12 @@ export class Output {
 		return generator.toString();
 
 		function relativeToOutput(fileName: string) {
-			const absolute = path.resolve(directory, fileName);
-			return utils.forwardSlashes(path.relative(output.base, absolute));
+		        const sourceDirAbsolute = path.parse(path.resolve(directory, fileName)).dir;
+            		const destDirAbsolute = path.parse(output.path).dir;
+            		const fileName = path.parse(fileName).base;
+            		const sourcePathRelativeToDestPath = path.relative( destDirAbsolute, sourceDirAbsolute);
+            		const fullRelativeSourcePath = utils.forwardSlashes(sourcePathRelativeToDestPath) + "/" +  fileName;
+            		return fullRelativeSourcePath;
 		}
 	}
 


### PR DESCRIPTION
Alternatively, if the compiler seems to be giving the correct relative paths anyway could this be left out maybe?