### PR TITLE
Update test gulp tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.10"
+  - "node"
+  - "lts/*"
 notifications:
   email: false

--- a/test/baselines/basic/2.3/errors.txt
+++ b/test/baselines/basic/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/basic/2.4/errors.txt
+++ b/test/baselines/basic/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/basic/dev/errors.txt
+++ b/test/baselines/basic/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/bom/2.3/errors.txt
+++ b/test/baselines/bom/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/bom/2.4/errors.txt
+++ b/test/baselines/bom/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/bom/dev/errors.txt
+++ b/test/baselines/bom/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/existingSourceMaps/2.3/errors.txt
+++ b/test/baselines/existingSourceMaps/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/existingSourceMaps/2.4/errors.txt
+++ b/test/baselines/existingSourceMaps/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/existingSourceMaps/dev/errors.txt
+++ b/test/baselines/existingSourceMaps/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/externalResolve/2.3/errors.txt
+++ b/test/baselines/externalResolve/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/externalResolve/2.4/errors.txt
+++ b/test/baselines/externalResolve/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/externalResolve/dev/errors.txt
+++ b/test/baselines/externalResolve/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/out/2.3/errors.txt
+++ b/test/baselines/out/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/out/2.4/errors.txt
+++ b/test/baselines/out/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/out/dev/errors.txt
+++ b/test/baselines/out/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMaps/2.3/errors.txt
+++ b/test/baselines/sourceMaps/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMaps/2.4/errors.txt
+++ b/test/baselines/sourceMaps/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMaps/dev/errors.txt
+++ b/test/baselines/sourceMaps/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMapsOutDir/2.3/errors.txt
+++ b/test/baselines/sourceMapsOutDir/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMapsOutDir/2.4/errors.txt
+++ b/test/baselines/sourceMapsOutDir/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/sourceMapsOutDir/dev/errors.txt
+++ b/test/baselines/sourceMapsOutDir/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigExtends/2.3/errors.txt
+++ b/test/baselines/tsconfigExtends/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigExtends/2.4/errors.txt
+++ b/test/baselines/tsconfigExtends/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigExtends/dev/errors.txt
+++ b/test/baselines/tsconfigExtends/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigOutFile/2.3/errors.txt
+++ b/test/baselines/tsconfigOutFile/2.3/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigOutFile/2.4/errors.txt
+++ b/test/baselines/tsconfigOutFile/2.4/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/baselines/tsconfigOutFile/dev/errors.txt
+++ b/test/baselines/tsconfigOutFile/dev/errors.txt
@@ -1,4 +1,3 @@
-
 {
     "transpileErrors": 0,
     "optionsErrors": 0,

--- a/test/noEmit/gulptask.js
+++ b/test/noEmit/gulptask.js
@@ -1,7 +1,7 @@
-var gulp = require('gulp');
+const gulp = require('gulp');
 
 module.exports = function(newTS, lib, output, reporter) {
 	return gulp.src('test/noEmit/**/*.ts')
 		.pipe(newTS({ noEmit: true, typescript: lib, outFile: 'foo.js' }, reporter))
 		.pipe(gulp.dest(output));
-}
+};


### PR DESCRIPTION
Due to a mismatch in the argument and parameters of the `runTest`
function used to execute the test, failures were ignored.
This commit fixes the concerned functions and fixes this issue.

Closes ivogabe/gulp-typescript#544