### PR TITLE
Fix minimal support for project references

### DIFF
--- a/lib/host.ts
+++ b/lib/host.ts
@@ -89,4 +89,7 @@ export class Host implements ts.CompilerHost {
 	getDirectories = (path: string) => this.fallback.getDirectories(path);
 
 	directoryExists = (path: string) => this.fallback.directoryExists(path);
+
+	readDirectory = (rootDir: string, extensions: string[], excludes: string[], includes: string[], depth?: number) => 
+		this.fallback.readDirectory(rootDir, extensions, excludes, includes, depth)
 }


### PR DESCRIPTION
TypeScript 3.1 requires that the `CompilerHost` for a program with project references must support `readDirectory`. This change adds `readDirectory` support via the fallback compiler host.

cc: @ivogabe
