### PR TITLE
Fix: TypeScript 3.1.1+ requires that a compiler host implement `readDirectory` if `projectReferences` are used.

### DIFF
--- a/lib/host.ts
+++ b/lib/host.ts
@@ -89,4 +89,7 @@ export class Host implements ts.CompilerHost {
 	getDirectories = (path: string) => this.fallback.getDirectories(path);
 
 	directoryExists = (path: string) => this.fallback.directoryExists(path);
+
+	readDirectory = (path: string, extensions?: ReadonlyArray<string>, exclude?: ReadonlyArray<string>, include?: ReadonlyArray<string>, depth?: number) =>
+		this.fallback.readDirectory(path, extensions, exclude, include, depth);
 }


### PR DESCRIPTION
See https://github.com/Microsoft/TypeScript/pull/26851 for details on that change in TypeScript

Without this change, gulp-typescript that is compiling a project that uses `projectReferences` would throw an error:

>     "Error: Debug Failure. 'CompilerHost.readDirectory' must be implemented to correctly process 'projectReferences'"

The fix is to use the `readDirectory` method from the TypeScript provided compiler host, similar to what is already done for `realpath`, `getDirectories` and `directoryExists`.