### PR TITLE
Replace execFile with exec to fix tests on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,7 +156,7 @@ async function runExecTest(testName) {
 	const testDir = path.posix.join('test', testName);
 
 	return new Promise((resolve, reject) => {
-		childProcess.execFile("gulp", {
+		childProcess.exec("gulp", {
 			cwd: testDir,
 		}, (err) => {
 			if (err) {


### PR DESCRIPTION
I got a mail that the tests failed on Windows because of the use of execFile. `execFile` executes a command without opening a shell, whereas `exec` will first open a shell and then execute a command. I think that a shell is needed for Windows, as it did work on Mac and Linux.

@lddubeau Do you agree with this change?

(The commit name should be the other way around..)