### PR TITLE
fix(fullReporter): Fix off-by-one display issue

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -132,7 +132,7 @@ export function fullReporter(fullFilename: boolean = false): Reporter {
 				const logLine = (lineIndex: number, errorStart: number, errorEnd?: number) => {
 					const line = lines[lineIndex];
 					if (errorEnd === undefined) errorEnd = line.length;
-					console.log('> ' + colors.gray('[' + lineIndex + '] ')
+					console.log('> ' + colors.gray('[' + (lineIndex + 1) + '] ')
 						+ line.substring(0, errorStart)
 						+ colors.red(line.substring(errorStart, errorEnd))
 						+ line.substring(errorEnd)
@@ -141,8 +141,8 @@ export function fullReporter(fullFilename: boolean = false): Reporter {
 
 				for (let i = error.startPosition.line; i <= error.endPosition.line; i++) {
 					logLine(i,
-						i === error.startPosition.line ? error.startPosition.character - 1 : 0,
-						i === error.endPosition.line ? error.endPosition.character - 1 : undefined
+						i === error.startPosition.line ? error.startPosition.character : 0,
+						i === error.endPosition.line ? error.endPosition.character : undefined
 					);
 				}
 			}

--- a/release/reporter.js
+++ b/release/reporter.js
@@ -91,13 +91,13 @@ function fullReporter(fullFilename = false) {
                     const line = lines[lineIndex];
                     if (errorEnd === undefined)
                         errorEnd = line.length;
-                    console.log('> ' + colors.gray('[' + lineIndex + '] ')
+                    console.log('> ' + colors.gray('[' + (lineIndex + 1) + '] ')
                         + line.substring(0, errorStart)
                         + colors.red(line.substring(errorStart, errorEnd))
                         + line.substring(errorEnd));
                 };
                 for (let i = error.startPosition.line; i <= error.endPosition.line; i++) {
-                    logLine(i, i === error.startPosition.line ? error.startPosition.character - 1 : 0, i === error.endPosition.line ? error.endPosition.character - 1 : undefined);
+                    logLine(i, i === error.startPosition.line ? error.startPosition.character : 0, i === error.endPosition.line ? error.endPosition.character : undefined);
                 }
             }
         },


### PR DESCRIPTION
### SUMMARY

Tweak the `fullReporter` slightly to display the correct line and column highlighting.

### TESTS

No tests included; I don't see an easy way to provide a test for a reporter given the current approach, but let me know if I'm missing something.

### TEST CASE

Using this example build, here are before and after screenshots of the output...

```js
// gulpfile.js
module.exports.default = () => {
    const ts = typescript.createProject('tsconfig.json', typescript.reporter.fullReporter());
    return gulp.src('src/ts/example.ts')
        .pipe(ts(typescript.reporter.fullReporter())).js
        .pipe(gulp.dest('dist'));
};
```

```js
// src/ts/example.ts
export function example() {
    console.log(Math.squeak());
}
```
#### BEFORE SCREENSHOT
<img width="850" alt="Screen Shot 2019-07-01 at 7 31 53 AM" src="https://user-images.githubusercontent.com/58273/60433532-125cff00-9bd3-11e9-9a97-2ceb65188cea.png">

#### AFTER SCREENSHOT
<img width="847" alt="Screen Shot 2019-07-01 at 7 29 51 AM" src="https://user-images.githubusercontent.com/58273/60433546-19840d00-9bd3-11e9-807e-eec0bb54f12f.png">

