### PR TITLE
Output declarations with emitDeclarationOnly

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -194,8 +194,6 @@ export class ProjectCompiler implements ICompiler {
 		}
 	}
 	private emitFile({ file, jsFileName, dtsFileName, dtsMapFileName, jsContent, dtsContent, dtsMapContent, jsMapContent }: OutputFile, currentDirectory: string) {
-		if (!jsFileName) return;
-
 		let base: string;
 		let baseDeclarations: string;
 		if (file) {
@@ -215,7 +213,9 @@ export class ProjectCompiler implements ICompiler {
 		} else {
 			base = this.project.directory;
 			baseDeclarations = base;
-			jsFileName = path.resolve(base, jsFileName);
+			if (jsFileName !== undefined) {
+				jsFileName = path.resolve(base, jsFileName);
+			}
 			if (dtsFileName !== undefined) {
 				dtsFileName = path.resolve(base, dtsFileName);
 			}

--- a/test/baselines/emitDeclarationOnly/2.9/dts/a.d.ts
+++ b/test/baselines/emitDeclarationOnly/2.9/dts/a.d.ts
@@ -1,0 +1,3 @@
+export declare class Hello {
+  value: string;
+}

--- a/test/baselines/emitDeclarationOnly/2.9/errors.txt
+++ b/test/baselines/emitDeclarationOnly/2.9/errors.txt
@@ -1,0 +1,10 @@
+{
+    "transpileErrors": 0,
+    "optionsErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "declarationErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/baselines/emitDeclarationOnly/dev/dts/a.d.ts
+++ b/test/baselines/emitDeclarationOnly/dev/dts/a.d.ts
@@ -1,0 +1,3 @@
+export declare class Hello {
+    value: string;
+}

--- a/test/baselines/emitDeclarationOnly/dev/errors.txt
+++ b/test/baselines/emitDeclarationOnly/dev/errors.txt
@@ -1,0 +1,10 @@
+{
+    "transpileErrors": 0,
+    "optionsErrors": 0,
+    "syntaxErrors": 0,
+    "globalErrors": 0,
+    "semanticErrors": 0,
+    "declarationErrors": 0,
+    "emitErrors": 0,
+    "emitSkipped": false
+}

--- a/test/emitDeclarationOnly/a.ts
+++ b/test/emitDeclarationOnly/a.ts
@@ -1,0 +1,3 @@
+export class Hello {
+	value: string;
+}

--- a/test/emitDeclarationOnly/gulptask.js
+++ b/test/emitDeclarationOnly/gulptask.js
@@ -1,0 +1,19 @@
+const gulp = require('gulp');
+
+module.exports = function(newTS, lib, output, reporter) {
+	const tsResult = gulp.src('test/emitDeclarationOnly/**/*.ts')
+		.pipe(newTS({ declaration: true, emitDeclarationOnly: true, typescript: lib }, reporter))
+		.on('error', () => {})
+
+	tsResult.dts.pipe(gulp.dest(output + 'dts'));
+	return tsResult.js.pipe(gulp.dest(output + 'js'));
+};
+
+module.exports.match = function (lib) {
+	// emitDeclarationOnly was added in TypeScript 2.8.
+	const match = /^(\d+)\.(\d+)/.exec(lib.version);
+	if (!match) return false
+	const major = parseInt(match[0])
+	const minor = parseInt(match[1])
+	return major > 2 || major === 2 && minor >= 8
+}


### PR DESCRIPTION
Previously, if there was no JavaScript output from a file, the output would be skipped entirely. This meant that when emitDeclarationOnly was enabled, the declarations would not be written to the `dts` stream.

Fixes #607.

One note on the test case: I found it actually passed even before making the change because `gulp-diff` only checks the files that exist in the stream. For example, if the stream is empty, the test will pass, even if there are files in the `baseline` directory. I did verify that, after my change, if the output differs, the test will fail.