### PR TITLE
feat: Add support for typescript .mts and .cts files

### DIFF
--- a/lib/compiler.ts
+++ b/lib/compiler.ts
@@ -156,6 +156,8 @@ export class ProjectCompiler implements ICompiler {
 		switch (extension) {
 			case 'js':
 			case 'jsx':
+			case 'mjs':
+			case 'cjs':
 				file.jsFileName = fileName;
 				file.jsContent = content;
 				break;

--- a/release/compiler.js
+++ b/release/compiler.js
@@ -101,6 +101,8 @@ class ProjectCompiler {
         switch (extension) {
             case 'js':
             case 'jsx':
+            case 'mjs':
+            case 'cjs':
                 file.jsFileName = fileName;
                 file.jsContent = content;
                 break;


### PR DESCRIPTION
Typescript supports new extensions .mts, .cts which will compile to .mjs and .cjs files.
Currently gulp-typescript only supports outputting .js and .jsx files.